### PR TITLE
The SendAsync method fails when Content-Length is > 2GB.

### DIFF
--- a/YoutubeExplode/Services/DefaultRequestService.cs
+++ b/YoutubeExplode/Services/DefaultRequestService.cs
@@ -62,7 +62,7 @@ namespace YoutubeExplode.Services
 
             try
             {
-                var response = await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, url));
+                var response = await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, url), HttpCompletionOption.ResponseHeadersRead);
                 return NormalizeResponseHeaders(response);
             }
             catch


### PR DESCRIPTION
Even using the 'HEAD' verb, the HttpClient tries to allocate a buffer for the Content. Adding HttpCompletionOption.ResponseHeadersRead parameter tells the HttpClient not to do this.