### PR TITLE
Added ConfigureAwait(false) to all awaited Tasks

### DIFF
--- a/YoutubeExplode/Services/DefaultRequestService.cs
+++ b/YoutubeExplode/Services/DefaultRequestService.cs
@@ -46,7 +46,7 @@ namespace YoutubeExplode.Services
 
             try
             {
-                return await _httpClient.GetStringAsync(url);
+                return await _httpClient.GetStringAsync(url).ConfigureAwait(false);
             }
             catch
             {
@@ -63,7 +63,8 @@ namespace YoutubeExplode.Services
             try
             {
                 using (var request = new HttpRequestMessage(HttpMethod.Head, url))
-                using (var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
+                using (var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                                                       .ConfigureAwait(false))
                     return NormalizeResponseHeaders(response);
             }
             catch
@@ -80,7 +81,8 @@ namespace YoutubeExplode.Services
 
             try
             {
-                return await _httpClient.GetStreamAsync(url);
+                return await _httpClient.GetStreamAsync(url)
+                                        .ConfigureAwait(false);
             }
             catch
             {

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -51,8 +51,8 @@ namespace YoutubeExplode
             if (playerSource == null)
             {
                 // Get the javascript source URL
-                string response =
-                    await _requestService.GetStringAsync($"https://www.youtube.com/yts/jsbin/player-{version}/base.js");
+                string response = await _requestService.GetStringAsync($"https://www.youtube.com/yts/jsbin/player-{version}/base.js")
+                                                       .ConfigureAwait(false);
                 if (response.IsBlank())
                     throw new Exception("Could not get the video player source code");
 
@@ -75,7 +75,7 @@ namespace YoutubeExplode
                 throw new Exception("Given video info does not need to be deciphered");
 
             // Get player source
-            var playerSource = await GetPlayerSourceAsync(videoInfo.PlayerVersion);
+            var playerSource = await GetPlayerSourceAsync(videoInfo.PlayerVersion).ConfigureAwait(false);
 
             // Unscramble streams
             foreach (var streamInfo in videoInfo.Streams.Where(s => s.NeedsDeciphering))
@@ -110,7 +110,8 @@ namespace YoutubeExplode
 
             // Get video info
             string eurl = $"https://youtube.googleapis.com/v/{videoId}".UrlEncode();
-            string response = await _requestService.GetStringAsync($"https://www.youtube.com/get_video_info?video_id={videoId}&sts=17221&eurl={eurl}");
+            string response = await _requestService.GetStringAsync($"https://www.youtube.com/get_video_info?video_id={videoId}&sts=17221&eurl={eurl}")
+                                                   .ConfigureAwait(false);
             if (response.IsBlank())
                 throw new Exception("Could not get video info");
 
@@ -120,7 +121,8 @@ namespace YoutubeExplode
                 throw new Exception("Could not parse video info");
 
             // Get player version
-            response = await _requestService.GetStringAsync($"https://www.youtube.com/watch?v={videoId}&gl=US&hl=en&has_verified=1&bpctr=9999999999");
+            response = await _requestService.GetStringAsync($"https://www.youtube.com/watch?v={videoId}&gl=US&hl=en&has_verified=1&bpctr=9999999999")
+                                            .ConfigureAwait(false);
             if (response.IsBlank())
                 throw new Exception("Could not get player version");
 
@@ -130,14 +132,15 @@ namespace YoutubeExplode
             // Decipher
             if (result.NeedsDeciphering)
             {
-                await DecipherAsync(result);
+                await DecipherAsync(result).ConfigureAwait(false);
             }
 
             // Get additional streams from dash if available
             if (result.DashManifest != null)
             {
                 // Get
-                response = await _requestService.GetStringAsync(result.DashManifest.Url);
+                response = await _requestService.GetStringAsync(result.DashManifest.Url)
+                                                .ConfigureAwait(false);
                 if (response.IsBlank())
                     throw new Exception("Could not get dash manifest");
 
@@ -159,7 +162,7 @@ namespace YoutubeExplode
             if (ShouldGetVideoFileSizes)
             {
                 foreach (var streamInfo in result.Streams)
-                    await GetFileSizeAsync(streamInfo);
+                    await GetFileSizeAsync(streamInfo).ConfigureAwait(false);
             }
 
             return result;
@@ -178,7 +181,8 @@ namespace YoutubeExplode
                 throw new Exception("Given stream's signature needs to be deciphered first");
 
             // Get the headers
-            var headers = await _requestService.GetHeadersAsync(streamInfo.Url);
+            var headers = await _requestService.GetHeadersAsync(streamInfo.Url)
+                                               .ConfigureAwait(false);
             if (headers == null)
                 throw new Exception("Could not obtain headers");
 
@@ -203,7 +207,8 @@ namespace YoutubeExplode
                 throw new Exception("Given stream's signature needs to be deciphered first");
 
             // Get stream
-            var stream = await _requestService.GetStreamAsync(streamInfo.Url);
+            var stream = await _requestService.GetStreamAsync(streamInfo.Url)
+                                              .ConfigureAwait(false);
             if (stream == null)
                 throw new Exception("Could not get response stream");
 


### PR DESCRIPTION
ConfigureAwait(false) allows a method to continue on a different thread it was first called on. This is very minor improvement but is it in general a good idea to use this in libraries.
Here some more info on ConfigureAwait: https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async/Async-library-methods-should-consider-using-Task-ConfigureAwait-false-