### PR TITLE
Throw exception for YouTube Red videos

### DIFF
--- a/YoutubeExplode/Exceptions/VideoRequiresPurchaseException.cs
+++ b/YoutubeExplode/Exceptions/VideoRequiresPurchaseException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace YoutubeExplode.Exceptions
+{
+    /// <summary>
+    /// Thrown when the video is a paid Youtube Red video since then we have no access to more video details
+    /// </summary>
+    public class VideoRequiresPurchaseException : Exception
+    {
+        /// <inheritdoc />
+        public VideoRequiresPurchaseException()
+            : base()
+        {
+        }
+    }
+}

--- a/YoutubeExplode/Exceptions/VideoRequiresPurchaseException.cs
+++ b/YoutubeExplode/Exceptions/VideoRequiresPurchaseException.cs
@@ -9,7 +9,7 @@ namespace YoutubeExplode.Exceptions
     {
         /// <inheritdoc />
         public VideoRequiresPurchaseException()
-            : base()
+            : base("The video is a paid Youtube Red video and cannot be processed")
         {
         }
     }

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -207,7 +207,7 @@ namespace YoutubeExplode
             }
 
             // Check for paid content
-            if (videoInfoDic.ContainsKey("requires_purchase") && videoInfoDic.Get("requires_purchase") == "1")
+            if (videoInfoDic.GetOrDefault("requires_purchase") == "1")
             {
                 throw new VideoRequiresPurchaseException();
             }

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -410,10 +410,17 @@ namespace YoutubeExplode
 
                     // Fix for Hebrew
                     if (lang == "iw") lang = "he";
+                    // Fix for Yi
+                    if (lang == "yi") lang = "ii";
 
-                    var culture = new CultureInfo(lang);
-                    var caption = new ClosedCaptionTrackInfo(url, culture, isAuto);
-                    captions.Add(caption);
+                    try {
+                        // Culture will not be found if it is unsupported by the current running system
+                        var culture = new CultureInfo(lang);
+                        var caption = new ClosedCaptionTrackInfo(url, culture, isAuto);
+                        captions.Add(caption);
+                    } catch (CultureNotFoundException) {
+                        continue;
+                    }
                 }
             }
 

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -206,6 +206,12 @@ namespace YoutubeExplode
                 throw new VideoNotAvailableException(errorCode, errorReason);
             }
 
+            // Check for paid content
+            if (videoInfoDic.ContainsKey("requires_purchase") && videoInfoDic.Get("requires_purchase") == "1")
+            {
+                throw new VideoRequiresPurchaseException();
+            }
+
             // Parse metadata
             string title = videoInfoDic.Get("title");
             var duration = TimeSpan.FromSeconds(videoInfoDic.Get("length_seconds").ParseDouble());

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -410,17 +410,10 @@ namespace YoutubeExplode
 
                     // Fix for Hebrew
                     if (lang == "iw") lang = "he";
-                    // Fix for Yi
-                    if (lang == "yi") lang = "ii";
 
-                    try {
-                        // Culture will not be found if it is unsupported by the current running system
-                        var culture = new CultureInfo(lang);
-                        var caption = new ClosedCaptionTrackInfo(url, culture, isAuto);
-                        captions.Add(caption);
-                    } catch (CultureNotFoundException) {
-                        continue;
-                    }
+                    var culture = new CultureInfo(lang);
+                    var caption = new ClosedCaptionTrackInfo(url, culture, isAuto);
+                    captions.Add(caption);
                 }
             }
 


### PR DESCRIPTION
I added a `VideoRequiresPurchaseException` which is thrown when the video requires a purchase. If so, we have no access to most video details. [Example video](https://www.youtube.com/watch?v=p3dDcKOFXQg)