### PR TITLE
Views element is optional sometimes in playlist metadata

### DIFF
--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -540,7 +540,7 @@ namespace YoutubeExplode
             var author = playlistInfoXml.Element("author")?.Value ?? "";
             var description = playlistInfoXml.ElementStrict("description").Value;
             //Some playlists like WatchLater (WL) does not contain the views element.
-            var viewCount = (long?)playlistInfoXml.Element("views") ?? 0;
+            var viewCount = (long?) playlistInfoXml.Element("views") ?? 0;
 
             return new PlaylistInfo(playlistId, title, author, description, viewCount, videos);
         }

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -539,7 +539,6 @@ namespace YoutubeExplode
             var title = playlistInfoXml.ElementStrict("title").Value;
             var author = playlistInfoXml.Element("author")?.Value ?? "";
             var description = playlistInfoXml.ElementStrict("description").Value;
-            //Some playlists like WatchLater (WL) does not contain the views element.
             var viewCount = (long?) playlistInfoXml.Element("views") ?? 0;
 
             return new PlaylistInfo(playlistId, title, author, description, viewCount, videos);

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -540,7 +540,7 @@ namespace YoutubeExplode
             var author = playlistInfoXml.Element("author")?.Value ?? "";
             var description = playlistInfoXml.ElementStrict("description").Value;
             //Some playlists like WatchLater (WL) does not contain the views element.
-            var viewCount = playlistInfoXml.Element("views")?.Value.ParseLong() ?? 0L;
+            var viewCount = (long?)playlistInfoXml.Element("views") ?? 0;
 
             return new PlaylistInfo(playlistId, title, author, description, viewCount, videos);
         }

--- a/YoutubeExplode/YoutubeClient.cs
+++ b/YoutubeExplode/YoutubeClient.cs
@@ -539,7 +539,8 @@ namespace YoutubeExplode
             var title = playlistInfoXml.ElementStrict("title").Value;
             var author = playlistInfoXml.Element("author")?.Value ?? "";
             var description = playlistInfoXml.ElementStrict("description").Value;
-            var viewCount = (long) playlistInfoXml.ElementStrict("views");
+            //Some playlists like WatchLater (WL) does not contain the views element.
+            var viewCount = playlistInfoXml.Element("views")?.Value.ParseLong() ?? 0L;
 
             return new PlaylistInfo(playlistId, title, author, description, viewCount, videos);
         }


### PR DESCRIPTION
Some playlists like WatchLater (WL), maybe other private playlists as well, do not contain the views element in the metadata.
So I made it optional in GetPlaylistInfoAsync.