### PR TITLE
YouTube Live Streaming HLS Support

### DIFF
--- a/YoutubeExplode/Models/MediaStreams/MediaStreamInfoSet.cs
+++ b/YoutubeExplode/Models/MediaStreams/MediaStreamInfoSet.cs
@@ -23,14 +23,21 @@ namespace YoutubeExplode.Models.MediaStreams
         /// </summary>
         public IReadOnlyList<VideoStreamInfo> Video { get; }
 
+        /// <summary>
+        /// Raw HTTP Live Streaming (HLS) url to the m3u8 playlist.
+        /// Will be null if not a live stream.
+        /// </summary>
+        public string HlsLiveStreamUrl { get; }
+
         /// <summary />
         public MediaStreamInfoSet(IReadOnlyList<MuxedStreamInfo> muxed,
             IReadOnlyList<AudioStreamInfo> audio,
-            IReadOnlyList<VideoStreamInfo> video)
+            IReadOnlyList<VideoStreamInfo> video, string hlsLiveStreamUrl)
         {
             Muxed = muxed.GuardNotNull(nameof(muxed));
             Audio = audio.GuardNotNull(nameof(audio));
             Video = video.GuardNotNull(nameof(video));
+            HlsLiveStreamUrl = hlsLiveStreamUrl;
         }
     }
 }

--- a/YoutubeExplode/Models/MediaStreams/MediaStreamInfoSet.cs
+++ b/YoutubeExplode/Models/MediaStreams/MediaStreamInfoSet.cs
@@ -32,7 +32,8 @@ namespace YoutubeExplode.Models.MediaStreams
         /// <summary />
         public MediaStreamInfoSet(IReadOnlyList<MuxedStreamInfo> muxed,
             IReadOnlyList<AudioStreamInfo> audio,
-            IReadOnlyList<VideoStreamInfo> video, string hlsLiveStreamUrl)
+            IReadOnlyList<VideoStreamInfo> video, 
+            string hlsLiveStreamUrl)
         {
             Muxed = muxed.GuardNotNull(nameof(muxed));
             Audio = audio.GuardNotNull(nameof(audio));

--- a/YoutubeExplode/YoutubeClient.Video.cs
+++ b/YoutubeExplode/YoutubeClient.Video.cs
@@ -456,12 +456,15 @@ namespace YoutubeExplode
                 }
             }
 
+            // Get the raw HLS stream playlist (*.m3u8)
+            var hlsLiveStreamUrl = videoInfo.GetOrDefault("hlsvp");
+
             // Finalize stream info collections
             muxedStreamInfos = muxedStreamInfos.Distinct(s => s.Itag).OrderByDescending(s => s.VideoQuality).ToList();
             audioStreamInfos = audioStreamInfos.Distinct(s => s.Itag).OrderByDescending(s => s.Bitrate).ToList();
             videoStreamInfos = videoStreamInfos.Distinct(s => s.Itag).OrderByDescending(s => s.VideoQuality).ToList();
 
-            return new MediaStreamInfoSet(muxedStreamInfos, audioStreamInfos, videoStreamInfos);
+            return new MediaStreamInfoSet(muxedStreamInfos, audioStreamInfos, videoStreamInfos, hlsLiveStreamUrl);
         }
 
         /// <summary>


### PR DESCRIPTION
Expose the raw HLS playlist url (via `hlsvp`). This allows clients capable of playing .m3u8 files to play YouTube live streams.