### PR TITLE
added ability to download video in the highest available quality

### DIFF
--- a/DemoConsole/Program.cs
+++ b/DemoConsole/Program.cs
@@ -94,7 +94,7 @@ namespace DemoConsole
             id = NormalizeId(id);
 
             var progress = new Progress<double>(p => Console.Title = $"YoutubeExplode Demo [{p:P0}]");
-            await client.DownloadHighestQualityAsync(id, "", @"D:\Entwicklung\Programme\ffmpeg\bin\ffmpeg.exe", progress);
+            await client.DownloadHighestQualityAsync(id, "", @"YOURPATH\ffmpeg.exe", progress);
 
             Console.WriteLine("Download complete!");
             Console.ReadKey();

--- a/DemoConsole/Program.cs
+++ b/DemoConsole/Program.cs
@@ -83,6 +83,23 @@ namespace DemoConsole
             Console.ReadKey();
         }
 
+        private static async Task DownloadHighestQualityDemo()
+        {
+            // Client
+            var client = new YoutubeClient();
+
+            // Get the video ID
+            Console.Write("Enter YouTube video ID or URL: ");
+            var id = Console.ReadLine();
+            id = NormalizeId(id);
+
+            var progress = new Progress<double>(p => Console.Title = $"YoutubeExplode Demo [{p:P0}]");
+            await client.DownloadHighestQualityAsync(id, "", @"D:\Entwicklung\Programme\ffmpeg\bin\ffmpeg.exe", progress);
+
+            Console.WriteLine("Download complete!");
+            Console.ReadKey();
+        }
+
         public static void Main(string[] args)
         {
             // This demo prompts for video ID, gets video info and downloads one media stream
@@ -93,6 +110,9 @@ namespace DemoConsole
 
             // Main method in consoles cannot be asynchronous so we run everything synchronously
             MainAsync().GetAwaiter().GetResult();
+
+            // Demo for downloading highest available video and not capping at 720p
+            //DownloadHighestQualityDemo().GetAwaiter().GetResult();
         }
     }
 }

--- a/YoutubeExplode/Exceptions/FFmpegException.cs
+++ b/YoutubeExplode/Exceptions/FFmpegException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace YoutubeExplode.Exceptions
+{
+    /// <summary>
+    /// /// Thrown when there was an error muxing files.
+    /// </summary>
+    public class FFmpegException : Exception
+    {
+        /// <summary />
+        public FFmpegException(string message)
+            : base(message)
+        {
+
+        }
+    }
+}

--- a/YoutubeExplode/Internal/Extensions.cs
+++ b/YoutubeExplode/Internal/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -190,6 +191,13 @@ namespace YoutubeExplode.Internal
                 sb.AppendLine();
 
             return sb.ToString();
+        }
+
+        public static string GetValidFileName(this string fileName)
+        {
+            // Orginal code credit: https://stackoverflow.com/a/7393722
+            return Path.GetInvalidFileNameChars()
+                .Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
         }
     }
 }

--- a/YoutubeExplode/Internal/ffmpeg/LogLevel.cs
+++ b/YoutubeExplode/Internal/ffmpeg/LogLevel.cs
@@ -1,0 +1,15 @@
+﻿namespace YoutubeExplode.Internal.ffmpeg
+{
+    internal enum LogLevel
+    {
+        quiet,
+        panic,
+        fatal,
+        error,
+        warning,
+        info,
+        verbose,
+        debug,
+        trace
+    }
+}

--- a/YoutubeExplode/Internal/ffmpeg/Muxer.cs
+++ b/YoutubeExplode/Internal/ffmpeg/Muxer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics;
+using YoutubeExplode.Exceptions;
+
+namespace YoutubeExplode.Internal.ffmpeg
+{
+#if NETSTANDARD2_0 || NET45 || NETCOREAPP1_0
+    internal class Muxer : IDisposable
+    {
+        public string FFmpegPath { get; set; }
+
+        public bool OverwriteFiles { get; set; }
+
+        private Process _FFmpegProcess;
+
+        public Muxer(string fFmpegPath, bool overwriteFiles)
+        {
+            this.FFmpegPath = fFmpegPath;
+            this.OverwriteFiles = overwriteFiles;
+        }
+
+        public void Mux(string audioFile, string videoFile, string muxedFile, LogLevel logLevel)
+        {
+            var overwriteArgument = OverwriteFiles ? "-y" : "-n";
+
+            _FFmpegProcess = new Process();
+            _FFmpegProcess.EnableRaisingEvents = true;
+            _FFmpegProcess.StartInfo.FileName = FFmpegPath;
+            _FFmpegProcess.StartInfo.CreateNoWindow = true;
+            _FFmpegProcess.StartInfo.UseShellExecute = false;
+            _FFmpegProcess.StartInfo.RedirectStandardError = true;
+            _FFmpegProcess.StartInfo.Arguments = $"-v {logLevel} {overwriteArgument} -i \"{audioFile}\" -i \"{videoFile}\" -c copy \"{muxedFile}\"";
+            _FFmpegProcess.ErrorDataReceived += (s, e) =>
+            {
+                if (e.Data != null)
+                    throw new FFmpegException(e.Data);
+            };
+
+            _FFmpegProcess.Start();
+            _FFmpegProcess.BeginErrorReadLine();
+
+            _FFmpegProcess.WaitForExit();
+        }
+
+        public void Dispose()
+        {
+            _FFmpegProcess?.Dispose();
+        }
+    }
+#endif
+}

--- a/YoutubeExplode/YoutubeClient.Video.cs
+++ b/YoutubeExplode/YoutubeClient.Video.cs
@@ -516,19 +516,19 @@ namespace YoutubeExplode
 
 #if NETSTANDARD2_0 || NET45 || NETCOREAPP1_0
         /// <summary>
-        /// Gets the highest available video and audio and mixing them together and save the mixed video under the given path
+        /// Gets the highest available video and audio and muxing them together and save the muxed video under the given path
         /// </summary>
         public async Task DownloadHighestQualityAsync(string videoId, string filePath, string ffmpegPath)
             => await DownloadHighestQualityAsync(videoId, filePath, ffmpegPath, null).ConfigureAwait(false);
 
         /// <summary>
-        /// Gets the highest available video and audio and mixing them together and save the mixed video under the given path
+        /// Gets the highest available video and audio and muxing them together and save the muxed video under the given path
         /// </summary>
         public async Task DownloadHighestQualityAsync(string videoId, string filePath, string ffmpegPath, IProgress<double> progress)
             => await DownloadHighestQualityAsync(videoId, filePath, ffmpegPath, progress, CancellationToken.None);
 
         /// <summary>
-        /// Gets the highest available video and audio and mixing them together and save the mixed video under the given path
+        /// Gets the highest available video and audio and muxing them together and save the muxed video under the given path
         /// </summary>
         public async Task DownloadHighestQualityAsync(string videoId, string filePath, string ffmpegPath, IProgress<double> progress, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
…and not capping at 720p

The new function "DownloadHighestQualityAsync" downloads the video stream with highest available quality and the best audio stream which is compatible with the video stream.
Then the two streams get muxed by FFmpeg.

You need FFmpeg.exe saved on your computer and provide the path to the method.
I wanted to provide the user with the video title and full download size, but I could not find a suitable way.

I added a commented out example in the demo console