### PR TITLE
Handle cases where caption duration is not specified

### DIFF
--- a/YoutubeExplode/YoutubeClient.ClosedCaptionTrack.cs
+++ b/YoutubeExplode/YoutubeClient.ClosedCaptionTrack.cs
@@ -33,7 +33,8 @@ namespace YoutubeExplode
             {
                 var text = (string) captionXml;
                 var offset = TimeSpan.FromMilliseconds((double) captionXml.Attribute("t"));
-                var duration = TimeSpan.FromMilliseconds((double) captionXml.Attribute("d"));
+                var durationValue = captionXml.Attribute("d");
+                var duration = durationValue == null ? TimeSpan.Zero : TimeSpan.FromMilliseconds((double) durationValue);
 
                 var caption = new ClosedCaption(text, offset, duration);
                 captions.Add(caption);


### PR DESCRIPTION
There are some instances where the duration ("d" attribute) is not specified in the captions. This PR adds a check for this condition and sets the `TimeSpan` to zero

Here are a couple of sample videos which causes this:
https://www.youtube.com/watch?v=5bm5tT0bN7c
https://www.youtube.com/watch?v=xc3Gl4rnWV4

The easiest way to test this is to open either of these URLs in the WPF sample app and then try and download the english caption.