### PR TITLE
Set HttpCompletionOption.ResponseHeadersRead on all HTTP requests

### DIFF
--- a/YoutubeExplode.Tests/Data.cs
+++ b/YoutubeExplode.Tests/Data.cs
@@ -13,6 +13,7 @@ namespace YoutubeExplode.Tests
             yield return new TestCaseData("_kmeFXjjGfk"); // embed not allowed
             yield return new TestCaseData("5VGm0dczmHc"); // rating not allowed
             yield return new TestCaseData("ZGdLIwrGHG8"); // unlisted
+            yield return new TestCaseData("H1O_-JVbl_k"); // very large video
         }
 
         public static IEnumerable GetVideoIds_Invalid()

--- a/YoutubeExplode/Internal/HttpClientEx.cs
+++ b/YoutubeExplode/Internal/HttpClientEx.cs
@@ -30,7 +30,7 @@ namespace YoutubeExplode.Internal
             bool ensureSuccess = true)
         {
             using (var request = new HttpRequestMessage(HttpMethod.Get, requestUri))
-            using (var response = await httpClient.SendAsync(request).ConfigureAwait(false))
+            using (var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
             {
                 if (ensureSuccess)
                     response.EnsureSuccessStatusCode();
@@ -47,7 +47,7 @@ namespace YoutubeExplode.Internal
 
             using (request)
             {
-                var response = await httpClient.SendAsync(request).ConfigureAwait(false);
+                var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
                 if (ensureSuccess)
                     response.EnsureSuccessStatusCode();

--- a/YoutubeExplode/YoutubeClient.Video.cs
+++ b/YoutubeExplode/YoutubeClient.Video.cs
@@ -307,7 +307,7 @@ namespace YoutubeExplode
                     // Probe stream and get content length
                     long contentLength;
                     using (var request = new HttpRequestMessage(HttpMethod.Head, url))
-                    using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false))
+                    using (var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
                     {
                         // Some muxed streams can be gone
                         if (response.StatusCode == HttpStatusCode.NotFound ||


### PR DESCRIPTION
Fixes https://github.com/Tyrrrz/YoutubeExplode/issues/100

Added unit test case for large video that fails when this header isn't specified.