### PR TITLE
Fix finding player config in GetVideoEmbedPageAsync

### DIFF
--- a/YoutubeExplode/YoutubeClient.Video.cs
+++ b/YoutubeExplode/YoutubeClient.Video.cs
@@ -30,7 +30,7 @@ namespace YoutubeExplode
             // TODO: check if video is available
 
             var raw = await GetVideoEmbedPageRawAsync(videoId).ConfigureAwait(false);
-            var part = raw.SubstringAfter("yt.setConfig({'PLAYER_CONFIG': ").SubstringUntil(",'");
+            var part = raw.SubstringAfter("yt.setConfig({'PLAYER_CONFIG': ").SubstringUntil("});");
             return JToken.Parse(part);
         }
 


### PR DESCRIPTION
Change "'," to "});" when taking embeded video config.

I decided to use `});` since it seems more appropriate, because it starts taking config from `({'PLAYER_CONFIG': ` so it's only natural to seek for closing brackets.

Fixes #164