### PR TITLE
 Added parsing username from user url

### DIFF
--- a/YoutubeExplode.Tests/Data.cs
+++ b/YoutubeExplode.Tests/Data.cs
@@ -110,13 +110,8 @@ namespace YoutubeExplode.Tests
         public static IEnumerable GetUsernames()
         {
             yield return new TestCaseData("TheTyrrr");
-        }
-
-        public static IEnumerable GetPossibleUsernames()
-        {
-            yield return new TestCaseData("ABC");
-            yield return new TestCaseData("A1B2C3");
-            yield return new TestCaseData("12432");
+            yield return new TestCaseData("KannibalenRecords");
+            yield return new TestCaseData("JClayton1994");
         }
 
         public static IEnumerable GetUsernames_Invalid()

--- a/YoutubeExplode.Tests/Data.cs
+++ b/YoutubeExplode.Tests/Data.cs
@@ -110,6 +110,10 @@ namespace YoutubeExplode.Tests
         public static IEnumerable GetUsernames()
         {
             yield return new TestCaseData("TheTyrrr");
+        }
+
+        public static IEnumerable GetPossibleUsernames()
+        {
             yield return new TestCaseData("ABC");
             yield return new TestCaseData("A1B2C3");
             yield return new TestCaseData("12432");

--- a/YoutubeExplode.Tests/Data.cs
+++ b/YoutubeExplode.Tests/Data.cs
@@ -140,5 +140,24 @@ namespace YoutubeExplode.Tests
             yield return new TestCaseData("undead corporation megalomania");
             yield return new TestCaseData("white siberian fox");
         }
+
+        public static IEnumerable GetUserUrls()
+        {
+            yield return new TestCaseData("https://www.youtube.com/user/ProZD/", "ProZD");
+            yield return new TestCaseData("http://www.youtube.com/user/ProZD/", "ProZD");
+            yield return new TestCaseData("www.youtube.com/user/ProZD/", "ProZD");
+            yield return new TestCaseData("youtube.com/user/ProZD/", "ProZD");
+            yield return new TestCaseData("https://www.youtube.com/user/ProZD", "ProZD");
+        }
+
+        public static IEnumerable GetUserUrls_Invalid()
+        {
+            yield return new TestCaseData("https://www.youtube.com/user/P_roZD/"); // username cannot contain anything other than A-Z, a-z, 0-9
+            yield return new TestCaseData("http://www.youtube.com/user/Pr?-0oZD/");
+            yield return new TestCaseData("www.youtube.com/user/ProZD1234567890ABCDEF/"); // max allowed username is 20 character
+            yield return new TestCaseData("youtube.com/user//asdaz");
+            yield return new TestCaseData("https://www.example.com/user/ProZD/");
+            yield return new TestCaseData("youtube.com/");
+        }
     }
 }

--- a/YoutubeExplode.Tests/Data.cs
+++ b/YoutubeExplode.Tests/Data.cs
@@ -110,6 +110,17 @@ namespace YoutubeExplode.Tests
         public static IEnumerable GetUsernames()
         {
             yield return new TestCaseData("TheTyrrr");
+            yield return new TestCaseData("ABC");
+            yield return new TestCaseData("A1B2C3");
+            yield return new TestCaseData("12432");
+        }
+
+        public static IEnumerable GetUsernames_Invalid()
+        {
+            yield return new TestCaseData("The_Tyrrr");
+            yield return new TestCaseData("0123456789ABCDEFGHIJK"); // 21 characters
+            yield return new TestCaseData("A1B2C3-");
+            yield return new TestCaseData("=0123456789ABCDEF");
         }
 
         public static IEnumerable GetChannelIds_Invalid()

--- a/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
+++ b/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
@@ -166,7 +166,7 @@ namespace YoutubeExplode.Tests
         }
 
         [Test]
-        [TestCaseSource(typeof(Data), nameof(Data.GetPossibleUsernames))]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUsernames))]
         public void YoutubeClient_ValidateUsername_Test(string username)
         {
             var success = YoutubeClient.ValidateUsername(username);

--- a/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
+++ b/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
@@ -166,7 +166,7 @@ namespace YoutubeExplode.Tests
         }
 
         [Test]
-        [TestCaseSource(typeof(Data), nameof(Data.GetUsernames))]
+        [TestCaseSource(typeof(Data), nameof(Data.GetPossibleUsernames))]
         public void YoutubeClient_ValidateUsername_Test(string username)
         {
             var success = YoutubeClient.ValidateUsername(username);

--- a/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
+++ b/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
@@ -164,5 +164,40 @@ namespace YoutubeExplode.Tests
         {
             Assert.Throws<FormatException>(() => YoutubeClient.ParseChannelId(channelUrl));
         }
+
+        [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUserUrls))]
+        public void YoutubeClient_TryParseUsername_Test(string userUrl, string expectedUsername)
+        {
+            var success = YoutubeClient.TryParseUsername(userUrl, out string username);
+
+            Assert.That(success, Is.True);
+            Assert.That(username, Is.EqualTo(expectedUsername));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUserUrls_Invalid))]
+        public void YoutubeClient_TryParseUsername_Invalid_Test(string userUrl)
+        {
+            var success = YoutubeClient.TryParseUsername(userUrl, out _);
+
+            Assert.That(success, Is.Not.True);
+        }
+
+        [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUserUrls))]
+        public void YoutubeClient_ParseUsername_Test(string userUrl, string expectedUsername)
+        {
+            var username = YoutubeClient.ParseUsername(userUrl);
+
+            Assert.That(username, Is.EqualTo(expectedUsername));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUserUrls_Invalid))]
+        public void YoutubeClient_ParseUsername_Invalid_Test(string userUrl)
+        {
+            Assert.Throws<FormatException>(() => YoutubeClient.ParseUsername(userUrl));
+        }
     }
 }

--- a/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
+++ b/YoutubeExplode.Tests/YoutubeClientUnitTests.cs
@@ -166,6 +166,25 @@ namespace YoutubeExplode.Tests
         }
 
         [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUsernames))]
+        public void YoutubeClient_ValidateUsername_Test(string username)
+        {
+            var success = YoutubeClient.ValidateUsername(username);
+
+            Assert.That(success, Is.True);
+        }
+
+        [Test]
+        [TestCaseSource(typeof(Data), nameof(Data.GetUsernames_Invalid))]
+        public void YoutubeClient_ValidateUsername_Invalid_Test(string username)
+        {
+            var success = YoutubeClient.ValidateUsername(username);
+
+            Assert.That(success, Is.Not.True);
+        }
+
+
+        [Test]
         [TestCaseSource(typeof(Data), nameof(Data.GetUserUrls))]
         public void YoutubeClient_TryParseUsername_Test(string userUrl, string expectedUsername)
         {
@@ -199,5 +218,6 @@ namespace YoutubeExplode.Tests
         {
             Assert.Throws<FormatException>(() => YoutubeClient.ParseUsername(userUrl));
         }
+
     }
 }

--- a/YoutubeExplode/YoutubeClient.Channel.cs
+++ b/YoutubeExplode/YoutubeClient.Channel.cs
@@ -31,7 +31,7 @@ namespace YoutubeExplode
             username.GuardNotNull(nameof(username));
 
             if (!ValidateUsername(username))
-                throw new ParseException("Could not parse channel ID.");
+                throw new ArgumentException($"Invalid YouTube username [{username}].");
 
             // Get user page
             var userPage = await GetUserPageAsync(username).ConfigureAwait(false);

--- a/YoutubeExplode/YoutubeClient.Channel.cs
+++ b/YoutubeExplode/YoutubeClient.Channel.cs
@@ -30,6 +30,9 @@ namespace YoutubeExplode
         {
             username.GuardNotNull(nameof(username));
 
+            if (!ValidateUsername(username))
+                throw new ParseException("Could not parse channel ID.");
+
             // Get user page
             var userPage = await GetUserPageAsync(username).ConfigureAwait(false);
 

--- a/YoutubeExplode/YoutubeClient.Static.cs
+++ b/YoutubeExplode/YoutubeClient.Static.cs
@@ -216,5 +216,38 @@ namespace YoutubeExplode
                 ? result
                 : throw new FormatException($"Could not parse channel ID from given string [{channelUrl}].");
         }
+
+        /// <summary>
+        /// Tries to parses a username from a YouTube user URL
+        /// </summary>
+        public static bool TryParseUsername(string userUrl, out string username)
+        {
+            username = default(string);
+
+            if (userUrl.IsBlank())
+                return false;
+
+            var regularMatch = Regex.Match(userUrl, @"youtube\.com\/user\/([a-zA-Z0-9]{1,20})").Groups[1].Value;
+
+            if (regularMatch.IsNotBlank())
+            {
+                username = regularMatch;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Parses username from a YouTube user URL.
+        /// </summary>
+        public static string ParseUsername(string userUrl)
+        {
+            userUrl.GuardNotNull(nameof(userUrl));
+
+            return TryParseUsername(userUrl, out string username)
+                ? username
+                : throw new FormatException($"Could not parse username from given string [{userUrl}]");
+        }
     }
 }

--- a/YoutubeExplode/YoutubeClient.Static.cs
+++ b/YoutubeExplode/YoutubeClient.Static.cs
@@ -218,6 +218,22 @@ namespace YoutubeExplode
         }
 
         /// <summary>
+        /// Verifies that the given string is syntactically a valid YouTube username.
+        /// </summary>
+        public static bool ValidateUsername(string username)
+        {
+            if (username.IsBlank())
+                return false;
+
+            // Usernames can't be longer than 20 characters
+            if (username.Length > 20)
+                return false;
+
+            return !Regex.IsMatch(username, @"[^0-9a-zA-Z]");
+
+        }
+
+        /// <summary>
         /// Tries to parses a username from a YouTube user URL
         /// </summary>
         public static bool TryParseUsername(string userUrl, out string username)
@@ -227,9 +243,9 @@ namespace YoutubeExplode
             if (userUrl.IsBlank())
                 return false;
 
-            var regularMatch = Regex.Match(userUrl, @"youtube\.com\/user\/([a-zA-Z0-9]{1,20})(?:\/|$)", RegexOptions.Multiline).Groups[1].Value;
+            var regularMatch = Regex.Match(userUrl, @"youtube\.com\/user\/(.*?)(?:&|\/|$)").Groups[1].Value;
 
-            if (regularMatch.IsNotBlank())
+            if (regularMatch.IsNotBlank() && ValidateUsername(regularMatch))
             {
                 username = regularMatch;
                 return true;
@@ -247,7 +263,7 @@ namespace YoutubeExplode
 
             return TryParseUsername(userUrl, out string username)
                 ? username
-                : throw new FormatException($"Could not parse username from given string [{userUrl}]");
+                : throw new FormatException($"Could not parse username from given string [{userUrl}].");
         }
     }
 }

--- a/YoutubeExplode/YoutubeClient.Static.cs
+++ b/YoutubeExplode/YoutubeClient.Static.cs
@@ -227,7 +227,7 @@ namespace YoutubeExplode
             if (userUrl.IsBlank())
                 return false;
 
-            var regularMatch = Regex.Match(userUrl, @"youtube\.com\/user\/([a-zA-Z0-9]{1,20})").Groups[1].Value;
+            var regularMatch = Regex.Match(userUrl, @"youtube\.com\/user\/([a-zA-Z0-9]{1,20})(?:\/|$)", RegexOptions.Multiline).Groups[1].Value;
 
             if (regularMatch.IsNotBlank())
             {


### PR DESCRIPTION
This adds support for getting the username from a user URL.
`https://www.youtube.com/user/ProZD/` would return `ProZD` 