### PR TITLE
Fix YouTube signature changes.

### DIFF
--- a/YoutubeExplode/Internal/Parsers/PlayerSourceParser.cs
+++ b/YoutubeExplode/Internal/Parsers/PlayerSourceParser.cs
@@ -23,7 +23,7 @@ namespace YoutubeExplode.Internal.Parsers
             // Regexes found in this method have been sourced by contributors and from other projects
 
             // Find the name of the function that handles deciphering
-            var entryPoint = Regex.Match(_raw, @"(\w+)&&(\w+)\.set\(\w+,(\w+)\(\1\)\);return\s+\2").Groups[3].Value;
+            var entryPoint = Regex.Match(_raw, @"\bc\s*&&\s*d\.set\([^,]+\s*,\s*\([^)]*\)\s*\(\s*([a-zA-Z0-9$]+)\(").Groups[1].Value;
             if (entryPoint.IsBlank())
                 throw new ParseException("Could not find the entry function for signature deciphering.");
 


### PR DESCRIPTION
Implemented the regex changes found here: https://github.com/rg3/youtube-dl/commit/2511eee215c2a66020ae927c86face826f48ba8e

Fixes #179. 

I've done a fair amount of testing on multiple videos that were broken before, and everything seems to be working fine.

I haven't tested how all the ciphers will react to the new entry point, just a random selection of normal and music videos. I've made the assumption that nothing else changed, so more testing may be required.