### PR TITLE
Replace keyword extraction regex

### DIFF
--- a/YoutubeExplode/YoutubeClient.Playlist.cs
+++ b/YoutubeExplode/YoutubeClient.Playlist.cs
@@ -11,6 +11,9 @@ namespace YoutubeExplode
 {
     public partial class YoutubeClient
     {
+        /// <remarks>double quotes are silently stripped from keywords so it's safe to pair them</remarks>
+        private const string KeywordRegex = "(\"[^\"]+\"|[^ ]+)";
+
         private async Task<JToken> GetPlaylistJsonAsync(string playlistId, int index)
         {
             var url = $"https://youtube.com/list_ajax?style=json&action_get_list=1&list={playlistId}&index={index}&hl=en";
@@ -56,10 +59,11 @@ namespace YoutubeExplode
 
                     // Extract video keywords
                     var videoKeywordsJoined = videoJson.SelectToken("keywords").Value<string>();
-                    var videoKeywords = Regex.Matches(videoKeywordsJoined, @"(?<=(^|\s)(?<q>""?))([^""]|(""""))*?(?=\<q>(?=\s|$))")
+                    var videoKeywords = Regex.Matches(videoKeywordsJoined, KeywordRegex)
                         .Cast<Match>()
                         .Select(m => m.Value)
                         .Where(s => !s.IsNullOrWhiteSpace())
+                        .Select(s => s.StartsWith("\"") ? s.Substring(1, s.Length - 2) : s)
                         .ToArray();
 
                     // Create statistics and thumbnails

--- a/YoutubeExplode/YoutubeClient.Playlist.cs
+++ b/YoutubeExplode/YoutubeClient.Playlist.cs
@@ -11,9 +11,6 @@ namespace YoutubeExplode
 {
     public partial class YoutubeClient
     {
-        /// <remarks>double quotes are silently stripped from keywords so it's safe to pair them</remarks>
-        private const string KeywordRegex = "(\"[^\"]+\"|[^ ]+)";
-
         private async Task<JToken> GetPlaylistJsonAsync(string playlistId, int index)
         {
             var url = $"https://youtube.com/list_ajax?style=json&action_get_list=1&list={playlistId}&index={index}&hl=en";
@@ -59,11 +56,11 @@ namespace YoutubeExplode
 
                     // Extract video keywords
                     var videoKeywordsJoined = videoJson.SelectToken("keywords").Value<string>();
-                    var videoKeywords = Regex.Matches(videoKeywordsJoined, KeywordRegex)
+                    var videoKeywords = Regex.Matches(videoKeywordsJoined, "\"[^\"]+\"|\\S+")
                         .Cast<Match>()
                         .Select(m => m.Value)
                         .Where(s => !s.IsNullOrWhiteSpace())
-                        .Select(s => s.StartsWith("\"") ? s.Substring(1, s.Length - 2) : s)
+                        .Select(s => s.Trim('"'))
                         .ToArray();
 
                     // Create statistics and thumbnails

--- a/YoutubeExplode/YoutubeClient.Search.cs
+++ b/YoutubeExplode/YoutubeClient.Search.cs
@@ -49,10 +49,11 @@ namespace YoutubeExplode
 
                     // Extract video keywords
                     var videoKeywordsJoined = videoJson.SelectToken("keywords").Value<string>();
-                    var videoKeywords = Regex.Matches(videoKeywordsJoined, @"(?<=(^|\s)(?<q>""?))([^""]|(""""))*?(?=\<q>(?=\s|$))")
+                    var videoKeywords = Regex.Matches(videoKeywordsJoined, KeywordRegex)
                         .Cast<Match>()
                         .Select(m => m.Value)
                         .Where(s => !s.IsNullOrWhiteSpace())
+                        .Select(s => s.StartsWith("\"") ? s.Substring(1, s.Length - 2) : s)
                         .ToArray();
 
                     // Create statistics and thumbnails

--- a/YoutubeExplode/YoutubeClient.Search.cs
+++ b/YoutubeExplode/YoutubeClient.Search.cs
@@ -49,11 +49,11 @@ namespace YoutubeExplode
 
                     // Extract video keywords
                     var videoKeywordsJoined = videoJson.SelectToken("keywords").Value<string>();
-                    var videoKeywords = Regex.Matches(videoKeywordsJoined, KeywordRegex)
+                    var videoKeywords = Regex.Matches(videoKeywordsJoined, "\"[^\"]+\"|\\S+")
                         .Cast<Match>()
                         .Select(m => m.Value)
                         .Where(s => !s.IsNullOrWhiteSpace())
-                        .Select(s => s.StartsWith("\"") ? s.Substring(1, s.Length - 2) : s)
+                        .Select(s => s.Trim('"'))
                         .ToArray();
 
                     // Create statistics and thumbnails


### PR DESCRIPTION
No idea what the previous regex was supposed to do, `(?=\<q>...)` seems malformed. It was probably overkill anyway as you can't actually save the double quote character in a keyword (though you can enter it and it will remain until the page is reloaded). You might be able to replace the `IsNullOrWhiteSpace` check with `IsNullOrEmpty` as well, you can't enter just a space.

I checked this [online](https://regex101.com), not by running the test suite.

edit: also, this isn't a valid playlist ID ([try it](https://youtube.com/watch?v=x2ZRoWQ0grU&list=RDEMNJhLy4rECJ_fG8NL-joqsg), should be `RDx2ZRoWQ0grU`):
https://github.com/Tyrrrz/YoutubeExplode/blob/847bb23bccff609bdcd61ef9ff22d4cc2f70b3c2/YoutubeExplode.Tests/TestData.cs#L109-L110