### PR TITLE
Use Uri.Escape method instead of Html.Encode

### DIFF
--- a/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
+++ b/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -127,7 +126,7 @@ namespace YoutubeExplode.ReverseEngineering.Responses
         public static async Task<PlaylistResponse> GetSearchResultsAsync(YoutubeHttpClient httpClient, string query, int page = 0) =>
             await Retry.WrapAsync(async () =>
             {
-                var queryEncoded = WebUtility.HtmlEncode(query);
+                var queryEncoded = Uri.EscapeUriString(query);
 
                 var url = $"https://youtube.com/search_ajax?style=json&search_query={queryEncoded}&page={page}&hl=en";
                 var raw = await httpClient.GetStringAsync(url, false); // don't ensure success but rather return empty list


### PR DESCRIPTION
After getting some weird search results in some cases I decided to investigate.
Apparently the search method uses `WebUtility.HtmlEncode()` to encode the query parameter.
This method is used to encode for actual HTML content on webpages.

Scenario;
`string query = "björn rosenström ragnar"` => `queryEncoded = "bj&#246;rn rosenstr&#246;m ragnar"`. As you can see `ö` gets translated to `&#246;` which is the HTML representation of that character. This also has the unfortunate side-effect of cutting off the search query almost entirely after the first two letters (before it encounters the HTML encoded character). 
The URI representation would be `bj%C3%B6rn%20rosenstr%C3%B6m%20ragnar` which should be more correct in this context, as we are making an API call with query parameters in the URL.

This PR should introduce more consistent search results, where an identical search term on the actual youtube website yields the same results as YoutubeExplode does.