### PR TITLE
Fix showing likes instead of dislikes

### DIFF
--- a/YoutubeExplode/Common/Engagement.cs
+++ b/YoutubeExplode/Common/Engagement.cs
@@ -38,6 +38,6 @@ namespace YoutubeExplode.Common
         }
 
         /// <inheritdoc />
-        public override string ToString() => $"{ViewCount:N0} views | {LikeCount:N0} likes | {LikeCount:N0} dislikes";
+        public override string ToString() => $"{ViewCount:N0} views | {LikeCount:N0} likes | {DislikeCount:N0} dislikes";
     }
 }


### PR DESCRIPTION
Noticed that `Engagement.ToString()` was showing the number of likes instead of dislikes.