### PR TITLE
Fix IO and ArgumentException in DemoConsole when full YouTube URL and ID supplied

### DIFF
--- a/YoutubeExplode.DemoConsole/Program.cs
+++ b/YoutubeExplode.DemoConsole/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using YoutubeExplode.DemoConsole.Internal;
+using YoutubeExplode.Videos;
 using YoutubeExplode.Videos.Streams;
 
 namespace YoutubeExplode.DemoConsole
@@ -19,10 +20,10 @@ namespace YoutubeExplode.DemoConsole
 
             // Read the video ID
             Console.Write("Enter YouTube video ID or URL: ");
-            var videoIdOrUrl = Console.ReadLine();
+            var videoId = new VideoId(Console.ReadLine());
 
             // Get media streams & choose the best muxed stream
-            var streams = await youtube.Videos.Streams.GetManifestAsync(videoIdOrUrl);
+            var streams = await youtube.Videos.Streams.GetManifestAsync(videoId);
             var streamInfo = streams.GetMuxed().WithHighestVideoQuality();
             if (streamInfo == null)
             {
@@ -31,7 +32,7 @@ namespace YoutubeExplode.DemoConsole
             }
 
             // Compose file name, based on metadata
-            var fileName = $"{videoIdOrUrl}.{streamInfo.Container.Name}";
+            var fileName = $"{videoId}.{streamInfo.Container.Name}";
 
             // Download video
             Console.Write($"Downloading stream: {streamInfo.VideoQualityLabel} / {streamInfo.Container.Name}... ");


### PR DESCRIPTION
# Steps to reproduce

- `$ cd YoutubeExplode.DemoConsole &&  dotnet build && dotnet run`
- `$ Enter YouTube video ID or URL: https://www.youtube.com/watch?v=Qz3VBGo9jJU`

# Actual behavior

> Enter YouTube video ID or URL: https://www.youtube.com/watch?v=Qz3VBGo9jJU
Downloading stream: 720p / mp4... Completed ✓
Unhandled exception. System.IO.DirectoryNotFoundException: Could not find a part of the path '/media/Shared/GitHub/YoutubeExplode/YoutubeExplode.DemoConsole/https:/www.youtube.com/watch?v=Qz3VBGo9jJU.mp4'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func\`2 errorRewriter)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
   at System.IO.FileStream.OpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize)
   at System.IO.File.Create(String path)
   at YoutubeExplode.Videos.Streams.StreamsClient.DownloadAsync(IStreamInfo streamInfo, String filePath, IProgress`1 progress, CancellationToken cancellationToken) in /media/Shared/GitHub/YoutubeExplode/YoutubeExplode/Videos/Streams/StreamsClient.cs:line 311
   at YoutubeExplode.DemoConsole.Program.Main() in /media/Shared/GitHub/YoutubeExplode/YoutubeExplode.DemoConsole/Program.cs:line 39
   at YoutubeExplode.DemoConsole.Program.\<Main\>()

# Steps to reproduce

- `$ cd YoutubeExplode.DemoConsole &&  dotnet build && dotnet run`
- `$ Enter YouTube video ID or URL: Qz3VBGo9jJU`

# Actual behavior

> Enter YouTube video ID or URL: Qz3VBGo9jJU
Unhandled exception. System.ArgumentException: Invalid YouTube video ID or URL: 'Qz3VBGo9jJU'.
   at YoutubeExplode.Videos.VideoId..ctor(String idOrUrl) in /media/Shared/GitHub/YoutubeExplode/YoutubeExplode/Videos/VideoId.cs:line 21
   at YoutubeExplode.Videos.VideoId.op_Implicit(String idOrUrl) in /media/Shared/GitHub/YoutubeExplode/YoutubeExplode/Videos/VideoId.cs:line 55
   at YoutubeExplode.DemoConsole.Program.Main() in /media/Shared/GitHub/YoutubeExplode/YoutubeExplode.DemoConsole/Program.cs:line 25
   at YoutubeExplode.DemoConsole.Program.\<Main\>()

# OS

- Ubuntu 20.04

# YouTubeExplode version

- [v5.0.5](https://github.com/Tyrrrz/YoutubeExplode/tree/5.0.5) (7a7b0cce9943c3f4423683f2a45ee5dcfec6fbae)