### PR TITLE
Add maxPages parameter when searching for videos

### DIFF
--- a/YoutubeExplode.Tests/SearchSpecs.cs
+++ b/YoutubeExplode.Tests/SearchSpecs.cs
@@ -33,5 +33,20 @@ namespace YoutubeExplode.Tests
             videos.Should().NotBeEmpty();
             videos.Should().HaveCountLessOrEqualTo(maxVideoCount);
         }
+
+        [Fact]
+        public async Task I_can_search_for_YouTube_videos_and_limit_the_total_loaded_page()
+        {
+            // Arrange
+            const int maxSearchRequest = 1;
+            var youtube = new YoutubeClient();
+
+            // Act
+            var videos = await youtube.Search.GetVideosAsync("billie eilish", maxSearchRequest);
+
+            // Assert
+            videos.Should().NotBeEmpty();
+            videos.Should().HaveCountLessOrEqualTo(30);
+        }
     }
 }

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -25,11 +25,11 @@ namespace YoutubeExplode.Search
         /// <summary>
         /// Enumerates videos returned by the specified search query.
         /// </summary>
-        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery)
+        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery, int maxPages = int.MaxValue)
         {
             var encounteredVideoIds = new HashSet<string>();
 
-            for (var page = 0; page < int.MaxValue; page++)
+            for (var page = 0; page < maxPages; page++)
             {
                 var response = await PlaylistResponse.GetSearchResultsAsync(_httpClient, searchQuery, page);
 


### PR DESCRIPTION
# Description

This feature enable us to limit how many requests will be sent towards YouTube when searching for Videos.

The variable name is the same as in [v4.7.16](https://github.com/Tyrrrz/YoutubeExplode/blob/4.7.16/YoutubeExplode/YoutubeClient.Search.cs#L23) (`maxPages`) but -my opinion is that- `maxRequestCount` could be a better choice (i named it in the test to `maxSearchRequest`).

# Introduce breaking change?

- No

# How to use

For example if you want only the Video results from the first search
page, then set it to 1.
You don't have to specify it if you want to get as many Videos as
possible.

# Note about the test case

I think the test case is not fully accurate because i ran a few tests and the search endpoint sometimes returned 22, 40 and even 60 results per page, so i would like to ask (i never used library like this) what do You think about checking how many times the `YoutubeHttpClient.SendAsync()` method was hit (this is the last library method what it gets called before actually requesting from YouTube)?