### PR TITLE
Add channelID in the video format

### DIFF
--- a/YoutubeExplode.Tests/ChannelSpecs.cs
+++ b/YoutubeExplode.Tests/ChannelSpecs.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -79,6 +80,7 @@ namespace YoutubeExplode.Tests
 
             // Assert
             videos.Should().HaveCountGreaterOrEqualTo(80);
+            videos.Select(v => v.ChannelId.Value.Should().Be("UCEnBXANsKmyj2r9xVyKoDiQ"));
         }
 
         [Theory]

--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -70,6 +70,7 @@ namespace YoutubeExplode.Tests
                 "VoGpvg3xXoE",
                 "Qzu-fTdjeFY"
             });
+            videos.Select(v => v.ChannelId.Value.Should().Be("UCEnBXANsKmyj2r9xVyKoDiQ"));
         }
 
         [Theory]

--- a/YoutubeExplode.Tests/SearchSpecs.cs
+++ b/YoutubeExplode.Tests/SearchSpecs.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -17,6 +18,7 @@ namespace YoutubeExplode.Tests
 
             // Assert
             videos.Should().NotBeEmpty();
+            videos.Select(v => v.ChannelId.Value.Length.Should().Be(24));
         }
 
         [Fact]

--- a/YoutubeExplode.Tests/VideoSpecs.cs
+++ b/YoutubeExplode.Tests/VideoSpecs.cs
@@ -23,6 +23,7 @@ namespace YoutubeExplode.Tests
             video.Url.Should().Be(videoUrl);
             video.Title.Should().Be("Aka no Ha [Another] +HDHR");
             video.Author.Should().Be("Tyrrrz");
+            video.ChannelId.Value.Should().Be("UCEnBXANsKmyj2r9xVyKoDiQ");
             video.UploadDate.Date.Should().Be(new DateTime(2017, 09, 30));
             video.Description.Should().Contain("246pp");
             video.Duration.Should().Be(new TimeSpan(00, 01, 48));

--- a/YoutubeExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeExplode/Playlists/PlaylistClient.cs
@@ -66,6 +66,7 @@ namespace YoutubeExplode.Playlists
                         videoId,
                         video.GetTitle(),
                         video.GetAuthor(),
+                        video.GetAuthorId(),
                         video.GetUploadDate(),
                         video.GetDescription(),
                         video.GetDuration(),

--- a/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
+++ b/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using YoutubeExplode.Channels;
 using YoutubeExplode.Exceptions;
 using YoutubeExplode.Internal;
 using YoutubeExplode.Internal.Extensions;
@@ -63,6 +64,11 @@ namespace YoutubeExplode.ReverseEngineering.Responses
             public string GetAuthor() => _root
                 .GetProperty("author")
                 .GetString();
+
+            public ChannelId GetAuthorId() => _root
+                .GetProperty("user_id")
+                .GetString()
+                .Pipe(id => "UC" + id);
 
             public DateTimeOffset GetUploadDate() => _root
                 .GetProperty("time_created")

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using YoutubeExplode.Common;
 using YoutubeExplode.ReverseEngineering;
@@ -46,6 +45,7 @@ namespace YoutubeExplode.Search
                         videoId,
                         video.GetTitle(),
                         video.GetAuthor(),
+                        video.GetAuthorId(),
                         video.GetUploadDate(),
                         video.GetDescription(),
                         video.GetDuration(),

--- a/YoutubeExplode/Videos/Video.cs
+++ b/YoutubeExplode/Videos/Video.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using YoutubeExplode.Channels;
 using YoutubeExplode.Common;
 
 namespace YoutubeExplode.Videos
@@ -28,6 +29,11 @@ namespace YoutubeExplode.Videos
         /// Video author.
         /// </summary>
         public string Author { get; }
+
+        /// <summary>
+        /// Video author ID.
+        /// </summary>
+        public ChannelId ChannelId { get; }
 
         /// <summary>
         /// Video upload date.
@@ -66,6 +72,7 @@ namespace YoutubeExplode.Videos
             VideoId id,
             string title,
             string author,
+            ChannelId authorId,
             DateTimeOffset uploadDate,
             string description,
             TimeSpan duration,
@@ -76,6 +83,7 @@ namespace YoutubeExplode.Videos
             Id = id;
             Title = title;
             Author = author;
+            ChannelId = authorId;
             UploadDate = uploadDate;
             Description = description;
             Duration = duration;

--- a/YoutubeExplode/Videos/VideoClient.cs
+++ b/YoutubeExplode/Videos/VideoClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using YoutubeExplode.Common;
 using YoutubeExplode.ReverseEngineering;
@@ -50,6 +49,7 @@ namespace YoutubeExplode.Videos
                 id,
                 playerResponse.GetVideoTitle(),
                 playerResponse.GetVideoAuthor(),
+                playerResponse.GetVideoChannelId(),
                 playerResponse.GetVideoUploadDate(),
                 playerResponse.GetVideoDescription(),
                 playerResponse.GetVideoDuration(),


### PR DESCRIPTION
This PR will enable us to get not only the Channel name (`Author` property) but the [ChannelId](https://github.com/Tyrrrz/YoutubeExplode/blob/10c9b63b2c0e2a66c1fb68a97b3d86d390e02b2b/YoutubeExplode/Channels/ChannelId.cs) too in these methods:

- [YoutubeClient.Channels.GetUploadsAsync(ChannelId id)](https://github.com/Tyrrrz/YoutubeExplode/blob/10c9b63b2c0e2a66c1fb68a97b3d86d390e02b2b/YoutubeExplode/Channels/ChannelClient.cs#L70)
- [YoutubeClient.Search.GetVideosAsync(string searchQuery)](https://github.com/Tyrrrz/YoutubeExplode/blob/10c9b63b2c0e2a66c1fb68a97b3d86d390e02b2b/YoutubeExplode/Search/SearchClient.cs#L28)
- [YoutubeClient.Playlists.GetVideosAsync(PlaylistId id)](https://github.com/Tyrrrz/YoutubeExplode/blob/516251580ec208f14765c23d854d4bce65ec86cf/YoutubeExplode/Playlists/PlaylistClient.cs#L47)
- [YoutubeClient.Videos.GetAsync(VideoId id)](https://github.com/Tyrrrz/YoutubeExplode/blob/45ffd17146d8dc2cd66ab0e6ad1bb038dbd6a31a/YoutubeExplode/Videos/VideoClient.cs#L42)

Closes #260 