### PR TITLE
Add search request limitation parameters

### DIFF
--- a/YoutubeExplode.Tests/SearchSpecs.cs
+++ b/YoutubeExplode.Tests/SearchSpecs.cs
@@ -33,5 +33,19 @@ namespace YoutubeExplode.Tests
             videos.Should().NotBeEmpty();
             videos.Should().HaveCountLessOrEqualTo(maxVideoCount);
         }
+
+        [Fact]
+        public async Task I_can_search_for_YouTube_videos_and_get_only_the_third_page()
+        {
+            // Arrange
+            var youtube = new YoutubeClient();
+
+            // Act
+            var videos = await youtube.Search.GetVideosAsync("billie eilish", firstPage: 2, takePage: 1);
+
+            // Assert
+            videos.Should().NotBeEmpty();
+            videos.Should().HaveCountLessOrEqualTo(30);
+        }
     }
 }

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -25,9 +25,18 @@ namespace YoutubeExplode.Search
         /// Enumerates videos returned by the specified search query.
         /// </summary>
         /// <param name="searchQuery">The term to look for.</param>
+        public IAsyncEnumerable<Video> GetVideosAsync(string searchQuery)
+        {
+            return GetVideosAsync(searchQuery, firstPage: 0, takePage: int.MaxValue);
+        }
+
+        /// <summary>
+        /// Enumerates videos returned by the specified search query.
+        /// </summary>
+        /// <param name="searchQuery">The term to look for.</param>
         /// <param name="firstPage">Sets how many page should be skipped from the beginning of the search.</param>
         /// <param name="takePage">Limits how many page should be requested to complete the search.</param>
-        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery, int firstPage = 0, int takePage = int.MaxValue)
+        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery, int firstPage, int takePage)
         {
             var encounteredVideoIds = new HashSet<string>();
 

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -24,11 +24,14 @@ namespace YoutubeExplode.Search
         /// <summary>
         /// Enumerates videos returned by the specified search query.
         /// </summary>
-        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery)
+        /// <param name="searchQuery">The term to look for.</param>
+        /// <param name="firstPage">Sets how many page should be skipped from the beginning of the search.</param>
+        /// <param name="takePage">Limits how many page should be requested to complete the search.</param>
+        public async IAsyncEnumerable<Video> GetVideosAsync(string searchQuery, int firstPage = 0, int takePage = int.MaxValue)
         {
             var encounteredVideoIds = new HashSet<string>();
 
-            for (var page = 0; page < int.MaxValue; page++)
+            for (var page = firstPage; page < firstPage + takePage; page++)
             {
                 var response = await PlaylistResponse.GetSearchResultsAsync(_httpClient, searchQuery, page);
 


### PR DESCRIPTION
Set `firstPage` to 1 if you want to skip the first page results from the
search pages and get everything after it.
Set `takePage` to 2 if you want to get the search results only from two
pages.

Closes #389