### PR TITLE
Return more specific error message when playlist is unavailable

### DIFF
--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
+using YoutubeExplode.Exceptions;
 
 namespace YoutubeExplode.Tests
 {
@@ -31,6 +32,28 @@ namespace YoutubeExplode.Tests
             playlist.Engagement.ViewCount.Should().BeGreaterOrEqualTo(133);
             playlist.Engagement.LikeCount.Should().BeGreaterOrEqualTo(0);
             playlist.Engagement.DislikeCount.Should().BeGreaterOrEqualTo(0);
+        }
+
+        [Fact]
+        public async Task I_cannot_get_metadata_of_a_private_YouTube_playlist()
+        {
+            // Arrange
+            const string playlistUrl = "https://www.youtube.com/playlist?list=PLYjTMWc3sa4ZKheRwyA1q56xxQrfQEUBr";
+            var youtube = new YoutubeClient();
+
+            // Act & assert
+            await Assert.ThrowsAsync<PlaylistUnavailableException>(() => youtube.Playlists.GetAsync(playlistUrl));
+        }
+
+        [Fact]
+        public async Task I_cannot_get_metadata_of_a_nonexistent_YouTube_playlist()
+        {
+            // Arrange
+            const string playlistUrl = "https://www.youtube.com/playlist?list=PLYjTMWc3sa4ZKheRwyA1q56xxQrfQEUBx";
+            var youtube = new YoutubeClient();
+
+            // Act & assert
+            await Assert.ThrowsAsync<PlaylistUnavailableException>(() => youtube.Playlists.GetAsync(playlistUrl));
         }
 
         [Theory]

--- a/YoutubeExplode/Exceptions/PlaylistUnavailableException.cs
+++ b/YoutubeExplode/Exceptions/PlaylistUnavailableException.cs
@@ -1,0 +1,30 @@
+namespace YoutubeExplode.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when the requested playlist is unavailable.
+    /// </summary>
+    public partial class PlaylistUnavailableException : YoutubeExplodeException
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="PlaylistUnavailableException"/>.
+        /// </summary>
+        public PlaylistUnavailableException(string message)
+            : base(message)
+        {
+        }
+    }
+
+    public partial class PlaylistUnavailableException
+    {
+        internal static PlaylistUnavailableException Unavailable(string playlistId)
+        {
+            var message = $@"
+Playlist '{playlistId}' is unavailable.
+In most cases, this error indicates that the playlist doesn't exist, is private, or has been taken down.
+If you can however open this video in your browser in incognito mode, it most likely means that YouTube changed something, which broke this library.
+Please report this issue on GitHub in that case.";
+
+            return new PlaylistUnavailableException(message.Trim());
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately we can't differentiate between the cases of a playlist being private, and one that doesn't exist. In both cases, the response returned is `400 : Bad Request`. This is intended as a fix for #445.

Closes #445