### PR TITLE
Fix httpClient.GetStreamAsync segmentSize overflow issue

### DIFF
--- a/YoutubeExplode/Internal/SegmentedHttpStream.cs
+++ b/YoutubeExplode/Internal/SegmentedHttpStream.cs
@@ -74,16 +74,10 @@ namespace YoutubeExplode.Internal
             // If current stream is not set - resolve it
             if (_currentStream == null)
             {
-                if (_segmentSize == null)
-                {
-                    // The current is not RateLimited - _segmentSize will be null
-                    _currentStream = await _httpClient.GetStreamAsync(_url, Position);
-                }
-                else
-                {
-                    // The current is RateLimited - use _segmentSize with Position to set 'to' stream position
-                    _currentStream = await _httpClient.GetStreamAsync(_url, Position, Position + _segmentSize - 1);
-                }
+                var from = Position;
+                var to = _segmentSize != null ?  Position + _segmentSize - 1 : null;
+                
+                _currentStream = await _httpClient.GetStreamAsync(_url, from, to);
             }
 
             // Read from current stream

--- a/YoutubeExplode/Internal/SegmentedHttpStream.cs
+++ b/YoutubeExplode/Internal/SegmentedHttpStream.cs
@@ -76,7 +76,7 @@ namespace YoutubeExplode.Internal
             {
                 if (_segmentSize == null)
                 {
-                    // The current is NOT RateLimited - _segmentSize will be null
+                    // The current is not RateLimited - _segmentSize will be null
                     _currentStream = await _httpClient.GetStreamAsync(_url, Position);
                 }
                 else

--- a/YoutubeExplode/ReverseEngineering/YoutubeHttpClient.cs
+++ b/YoutubeExplode/ReverseEngineering/YoutubeHttpClient.cs
@@ -83,7 +83,7 @@ namespace YoutubeExplode.ReverseEngineering
             return response.Content.Headers.ContentLength;
         }
 
-        public SegmentedHttpStream CreateSegmentedStream(string url, long length, long segmentSize) =>
+        public SegmentedHttpStream CreateSegmentedStream(string url, long length, long? segmentSize) =>
             new SegmentedHttpStream(this, url, length, segmentSize);
     }
 }

--- a/YoutubeExplode/Videos/Streams/StreamClient.cs
+++ b/YoutubeExplode/Videos/Streams/StreamClient.cs
@@ -284,9 +284,9 @@ namespace YoutubeExplode.Videos.Streams
             // so we'll be splitting the stream into small segments and retrieving them separately, to
             // work around rate limiting.
 
-            long? segmentSize = streamInfo.IsRateLimited()
+            var segmentSize = streamInfo.IsRateLimited()
                 ? 9_898_989 // this number was carefully devised through research
-                : default(long?); // don't use segmentation for non-rate-limited streams
+                : (long?) null; // don't use segmentation for non-rate-limited streams
 
             var stream = _httpClient.CreateSegmentedStream(streamInfo.Url, streamInfo.Size.TotalBytes, segmentSize);
 

--- a/YoutubeExplode/Videos/Streams/StreamClient.cs
+++ b/YoutubeExplode/Videos/Streams/StreamClient.cs
@@ -284,9 +284,9 @@ namespace YoutubeExplode.Videos.Streams
             // so we'll be splitting the stream into small segments and retrieving them separately, to
             // work around rate limiting.
 
-            var segmentSize = streamInfo.IsRateLimited()
+            long? segmentSize = streamInfo.IsRateLimited()
                 ? 9_898_989 // this number was carefully devised through research
-                : long.MaxValue; // don't use segmentation for non-rate-limited streams
+                : default(long?); // don't use segmentation for non-rate-limited streams
 
             var stream = _httpClient.CreateSegmentedStream(streamInfo.Url, streamInfo.Size.TotalBytes, segmentSize);
 


### PR DESCRIPTION
Following last comment on PR: https://github.com/Tyrrrz/YoutubeExplode/pull/448
Updated code so `_segmentSize` is nullable. (Will be null for Non-RateLimited video)