### PR TITLE
Don't escape search query

### DIFF
--- a/YoutubeExplode.Tests/SearchSpecs.cs
+++ b/YoutubeExplode.Tests/SearchSpecs.cs
@@ -20,6 +20,19 @@ namespace YoutubeExplode.Tests
         }
 
         [Fact]
+        public async Task I_can_search_for_YouTube_videos_with_escaped_characters()
+        {
+            // Arrange
+            var youtube = new YoutubeClient();
+
+            // Act
+            var videos = await youtube.Search.GetVideosAsync("Kill la Kill Gomen ne, Iiko ja Irarenai.");
+
+            // Assert
+            videos.Should().NotBeEmpty();
+        }
+
+        [Fact]
         public async Task I_can_search_for_YouTube_videos_and_get_a_subset_of_results()
         {
             // Arrange

--- a/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
+++ b/YoutubeExplode/ReverseEngineering/Responses/PlaylistResponse.cs
@@ -233,10 +233,8 @@ namespace YoutubeExplode.ReverseEngineering.Responses
         public static async Task<PlaylistResponse> GetSearchResultsAsync(YoutubeHttpClient httpClient, string query, string continuationToken = "") =>
             await Retry.WrapAsync(async () =>
             {
-                var queryEncoded = Uri.EscapeUriString(query);
-
                 const string url = "https://www.youtube.com/youtubei/v1/search?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
-                var payload = BuildPayload(queryEncoded, continuationToken);
+                var payload = BuildPayload(query, continuationToken);
                 var request = new HttpRequestMessage(HttpMethod.Post, url)
                 {
                     Content = new StringContent(payload, Encoding.UTF8, "application/json")


### PR DESCRIPTION
Youtube does not escape the query for the search call.  The added test fails without this change.