### PR TITLE
Ignore braces inside strings in `Json.Extract`

### DIFF
--- a/YoutubeExplode/Utils/Json.cs
+++ b/YoutubeExplode/Utils/Json.cs
@@ -11,19 +11,34 @@ namespace YoutubeExplode.Utils
             var buffer = new StringBuilder();
             var depth = 0;
 
+            var insideString = false;
+
             // We trust that the source contains valid json, we just need to extract it.
             // To do it, we will be matching curly braces until we even out.
             for (var i = 0; i < source.Length; i++)
             {
                 var ch = source[i];
-                var chPrv = i > 0 ? source[i - 1] : default;
+                var chNxt = i < source.Length - 1 ? source[i + 1] : default;
 
                 buffer.Append(ch);
 
-                // Match braces
-                if (ch == '{' && chPrv != '\\')
+                if (ch == '\\' && insideString && chNxt != default)
+                {
+                    // we've come across an escaped character.
+                    // consume it and the next character.
+                    buffer.Append(chNxt);
+                    i++; // skip the next character on the loop.
+                    continue;
+                }
+
+                // an unescaped quote, toggle our inside string status
+                if (ch == '"')
+                    insideString = !insideString;
+
+                // Match braces that are not inside strings
+                if (ch == '{' && !insideString)
                     depth++;
-                else if (ch == '}' && chPrv != '\\')
+                else if (ch == '}' && !insideString)
                     depth--;
 
                 // Break when evened out


### PR DESCRIPTION
Makes Json.Extract aware of whether or not the current character is inside of a string, and only count braces a that are not inside of sting.

This deals specifically with videos that have unmatched braces inside strings in their data. Example: watch?v=zSgiXGELjbc
