### PR TITLE
Add 'androidSdkVersion' to request

### DIFF
--- a/YoutubeExplode/Videos/VideoController.cs
+++ b/YoutubeExplode/Videos/VideoController.cs
@@ -60,7 +60,8 @@ internal class VideoController : YoutubeControllerBase
                 {
                     clientName = "ANDROID",
                     clientScreen = isEmbedded ? "EMBED" : null,
-                    clientVersion = "16.46.37",
+                    clientVersion = "17.29.35",
+                    androidSdkVersion = 30,
                     hl = "en",
                     gl = "US",
                     utcOffsetMinutes = 0


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
It looks like the issue that was causing the message was due to a new parameter YouTube looks for in their requests called `android_sdk_version`, as found out [here](https://github.com/iv-org/invidious/pull/3255). It looks like this just needs to be set to any valid Android SDK version number, and from my personal tests, it seems to have resolved the issue.

Closes #647
