### PR TITLE
Add Heatmap to Video

### DIFF
--- a/YoutubeExplode.Tests/TestData/VideoIds.cs
+++ b/YoutubeExplode.Tests/TestData/VideoIds.cs
@@ -10,6 +10,7 @@ internal static class VideoIds
     public const string LiveStreamRecording = "rsAAeyAr-9Y";
     public const string ContainsHighQualityStreams = "V5Fsj_sCKdg";
     public const string ContainsDashManifest = "AI7ULzgf8RU";
+    public const string ContainsHeatmap = "y43vWEPkceM";
     public const string Omnidirectional = "-xNN-bJQ4vI";
     public const string HighDynamicRange = "vX2vsvdq8nw";
     public const string ContainsClosedCaptions = "YltHGKX80Y8";

--- a/YoutubeExplode.Tests/VideoSpecs.cs
+++ b/YoutubeExplode.Tests/VideoSpecs.cs
@@ -41,6 +41,20 @@ public class VideoSpecs
         video.Engagement.LikeCount.Should().BeGreaterOrEqualTo(5);
         video.Engagement.DislikeCount.Should().BeGreaterOrEqualTo(0);
         video.Engagement.AverageRating.Should().BeGreaterOrEqualTo(0);
+        video.Heatmap.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task User_can_access_heatmap()
+    {
+        // Arrange
+        var youtube = new YoutubeClient();
+
+        // Act
+        var video = await youtube.Videos.GetAsync(VideoIds.ContainsHeatmap);
+
+        // Assert
+        video.Heatmap.Should().NotBeEmpty();
     }
 
     [Fact]

--- a/YoutubeExplode/Bridge/HeatmarkerExtractor.cs
+++ b/YoutubeExplode/Bridge/HeatmarkerExtractor.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json;
+using YoutubeExplode.Utils;
+using YoutubeExplode.Utils.Extensions;
+
+namespace YoutubeExplode.Bridge;
+
+internal class HeatmarkerExtractor
+{
+    private readonly JsonElement _content;
+
+    public HeatmarkerExtractor(JsonElement content) => _content = content;
+
+    public long? TryGetTimeRangeStartMillis() => Memo.Cache(this, () =>
+        _content.GetPropertyOrNull("heatMarkerRenderer")?.GetPropertyOrNull("timeRangeStartMillis")?.GetInt64OrNull()
+    );
+
+    public long? TryGetMarkerRangeStartMillis() => Memo.Cache(this, () =>
+        _content.GetPropertyOrNull("heatMarkerRenderer")?.GetPropertyOrNull("timeRangeStartMillis")?.GetInt64OrNull()
+    );
+
+    public decimal? TryGetHeatMarkerIntensityScoreNormalized() => Memo.Cache(this, () =>
+        _content.GetPropertyOrNull("heatMarkerRenderer")?.GetPropertyOrNull("heatMarkerIntensityScoreNormalized")?.GetDecimal()
+    );
+}

--- a/YoutubeExplode/Bridge/InitialDataExtractor.cs
+++ b/YoutubeExplode/Bridge/InitialDataExtractor.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using YoutubeExplode.Utils;
+using YoutubeExplode.Utils.Extensions;
+
+namespace YoutubeExplode.Bridge;
+
+internal partial class InitialDataExtractor
+{
+    private readonly JsonElement _content;
+
+    public InitialDataExtractor(JsonElement content) => _content = content;
+
+    public IReadOnlyList<HeatmarkerExtractor>? TryGetHeatmap() => Memo.Cache(this, () =>
+        _content
+            .GetPropertyOrNull("playerOverlays")?
+            .GetPropertyOrNull("playerOverlayRenderer")?
+            .GetPropertyOrNull("decoratedPlayerBarRenderer")?
+            .GetPropertyOrNull("decoratedPlayerBarRenderer")?
+            .GetPropertyOrNull("playerBar")?
+            .GetPropertyOrNull("multiMarkersPlayerBarRenderer")?
+            .GetPropertyOrNull("markersMap")?
+            .EnumerateArrayOrNull()?
+            .FirstOrNull()?
+            .GetPropertyOrNull("value")?
+            .GetPropertyOrNull("heatmap")?
+            .GetPropertyOrNull("heatmapRenderer")?
+            .GetPropertyOrNull("heatMarkers")?
+            .EnumerateArrayOrNull()?
+            .Select(j => new HeatmarkerExtractor(j))
+            .ToArray() ??
+        Array.Empty<HeatmarkerExtractor>()
+    );
+}

--- a/YoutubeExplode/Bridge/VideoWatchPageExtractor.cs
+++ b/YoutubeExplode/Bridge/VideoWatchPageExtractor.cs
@@ -49,6 +49,18 @@ internal partial class VideoWatchPageExtractor
             .Pipe(Json.TryParse)
     );
 
+    public InitialDataExtractor? TryGetInitialData() => Memo.Cache(this, () =>
+        _content
+            .GetElementsByTagName("script")
+            .Select(e => e.Text())
+            .Select(s => Regex.Match(s, @"var\s+ytInitialData\s*=\s*(\{.*\})").Groups[1].Value)
+            .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s))?
+            .NullIfWhiteSpace()?
+            .Pipe(Json.Extract)?
+            .Pipe(Json.TryParse)?
+            .Pipe(j => new InitialDataExtractor(j))
+    );
+
     public PlayerResponseExtractor? TryGetPlayerResponse() => Memo.Cache(this, () =>
         _content
             .GetElementsByTagName("script")

--- a/YoutubeExplode/Videos/Heatmap.cs
+++ b/YoutubeExplode/Videos/Heatmap.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace YoutubeExplode.Videos;
+
+/// <summary>
+/// Heatmap statistics.
+/// </summary>
+public class Heatmap
+{
+    /// <summary>
+    /// Time Range Starting in Milliseconds.
+    /// </summary>
+    public long TimeRangeStartMillis { get; }
+
+    /// <summary>
+    /// Marker Duration starting in Milliseconds.
+    /// </summary>
+    public long MarkerDurationMillis { get; }
+
+    /// <summary>
+    /// Heat Marker Insensity Score, normalized.
+    /// Range from 0 to 1.
+    /// </summary>
+    public decimal HeatMarkerIntensityScoreNormalized { get; }
+
+    /// <summary>
+    /// Initializes an instance of <see cref="Heatmap" />.
+    /// </summary>
+    public Heatmap(long timeRangeStartMillis, long markerDurationMillis, decimal heatMarkerIntensityScoreNormalized)
+    {
+        TimeRangeStartMillis = timeRangeStartMillis;
+        MarkerDurationMillis = markerDurationMillis;
+        HeatMarkerIntensityScoreNormalized = heatMarkerIntensityScoreNormalized;
+    }
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    public override string ToString() => $"Heatmap: {TimeRangeStartMillis},{MarkerDurationMillis},{HeatMarkerIntensityScoreNormalized}";
+}

--- a/YoutubeExplode/Videos/Streams/StreamClient.cs
+++ b/YoutubeExplode/Videos/Streams/StreamClient.cs
@@ -172,6 +172,7 @@ public class StreamClient
         var playerResponse = await _controller.GetPlayerResponseAsync(videoId, cancellationToken);
 
         var purchasePreviewVideoId = playerResponse.TryGetPreviewVideoId();
+
         if (!string.IsNullOrWhiteSpace(purchasePreviewVideoId))
         {
             throw new VideoRequiresPurchaseException(

--- a/YoutubeExplode/Videos/Video.cs
+++ b/YoutubeExplode/Videos/Video.cs
@@ -44,6 +44,13 @@ public class Video : IVideo
     public IReadOnlyList<string> Keywords { get; }
 
     /// <summary>
+    /// List of the most replayed sections on a video.
+    /// <see cref="Heatmap"/>
+    /// May not be available on all videos.
+    /// </summary>
+    public IReadOnlyList<Heatmap> Heatmap { get; }
+
+    /// <summary>
     /// Engagement statistics for the video.
     /// </summary>
     public Engagement Engagement { get; }
@@ -60,7 +67,8 @@ public class Video : IVideo
         TimeSpan? duration,
         IReadOnlyList<Thumbnail> thumbnails,
         IReadOnlyList<string> keywords,
-        Engagement engagement)
+        Engagement engagement,
+        IReadOnlyList<Heatmap> heatmap)
     {
         Id = id;
         Title = title;
@@ -71,6 +79,7 @@ public class Video : IVideo
         Thumbnails = thumbnails;
         Keywords = keywords;
         Engagement = engagement;
+        Heatmap = heatmap;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This PR adds "Heatmap" to the `video` object. 


<img width="591" alt="スクリーンショット 2022-10-26 15 01 58" src="https://user-images.githubusercontent.com/898335/197947091-7e2be992-3dc9-4b0d-a007-622c57686ee4.png">

YouTube started to offer a "heatmap" or "Most Replayed" view of (some) videos on their site. While not offered on every video, it can be useful for seeing which sections of a video are the most viewed or scrubbed through. My PR:

- Introduces a new InitialDataExtractor, which takes the InitialData object from the YouTube webpage and parses it.
- Introduces a HeatmapExtractor.
- Introduces Heatmap as a new object.

AFAIK, the only way to get access to this data is from this InitialData object, so I did not add it to the IVideo interface, since I think you can only get it when getting the player stats. I also added a new unit test for check for the existence of the item. If the video doesn't have a heatmap, it is empty rather than null.