### PR TITLE
Set StatusCode on HttpRequestException for .NET 5 and greater

### DIFF
--- a/YoutubeExplode/Bridge/YoutubeControllerBase.cs
+++ b/YoutubeExplode/Bridge/YoutubeControllerBase.cs
@@ -50,13 +50,17 @@ internal abstract class YoutubeControllerBase
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new HttpRequestException(
-                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode})." +
+            var message = $"Response status code does not indicate success: {(int)response.StatusCode} ({response.StatusCode})." +
                 Environment.NewLine +
                 "Request:" +
                 Environment.NewLine +
-                request
-            );
+                request;
+
+#if NET5_0_OR_GREATER
+            throw new HttpRequestException(message, null, response.StatusCode);
+#else
+            throw new HttpRequestException(message);
+#endif
         }
 
         return await response.Content.ReadAsStringAsync(cancellationToken);

--- a/YoutubeExplode/Bridge/YoutubeControllerBase.cs
+++ b/YoutubeExplode/Bridge/YoutubeControllerBase.cs
@@ -39,7 +39,7 @@ internal abstract class YoutubeControllerBase
         );
 
         // Special case check for rate limiting errors
-        if ((int) response.StatusCode == 429)
+        if ((int)response.StatusCode == 429)
         {
             throw new RequestLimitExceededException(
                 "Exceeded request rate limit. " +


### PR DESCRIPTION
...to spare consumers parsing it out of the message.

Helps with debugging inputs where a `404` has more meaning than other `HttpStatusCode`s.