### PR TITLE
implemented getting channel metadata by new @handle

### DIFF
--- a/YoutubeExplode.Tests/ChannelHandleSpecs.cs
+++ b/YoutubeExplode.Tests/ChannelHandleSpecs.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+using YoutubeExplode.Channels;
+
+namespace YoutubeExplode.Tests;
+
+public class ChannelHandleSpecs
+{
+    [Theory]
+    [InlineData("BeauMiles")]
+    [InlineData("a-z.0_9")]
+    public void Channel_handle_can_be_parsed_from_a_handle_string(string channelHandle)
+    {
+        // Act
+        var parsed = ChannelHandle.Parse(channelHandle);
+
+        // Assert
+        parsed.Value.Should().Be(channelHandle);
+    }
+
+    [Theory]
+    [InlineData("youtube.com/@BeauMiles", "BeauMiles")]
+    [InlineData("youtube.com/@a-z.0_9", "a-z.0_9")]
+    public void Channel_handle_can_be_parsed_from_a_URL_string(string channelUrl, string expectedChannelHandle)
+    {
+        // Act
+        var parsed = ChannelHandle.Parse(channelUrl);
+
+        // Assert
+        parsed.Value.Should().Be(expectedChannelHandle);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("foo bar")]
+    [InlineData("youtube.com/")]
+    [InlineData("youtube.com@BeauMiles")]
+    [InlineData("youtube.com/@=BeauMiles")]
+    [InlineData("youtube.com/@BeauMile$")]
+    [InlineData("youtube.com/@Beau+Miles")]
+    [InlineData("youtube.com/?@BeauMiles")]
+    public void Channel_handle_cannot_be_parsed_from_an_invalid_string(string channelHandleOrUrl)
+    {
+        // Act & assert
+        Assert.Throws<ArgumentException>(() => ChannelHandle.Parse(channelHandleOrUrl));
+    }
+}

--- a/YoutubeExplode.Tests/ChannelSpecs.cs
+++ b/YoutubeExplode.Tests/ChannelSpecs.cs
@@ -58,6 +58,22 @@ public class ChannelSpecs
     }
 
     [Fact]
+    public async Task User_can_get_metadata_of_a_channel_by_handle()
+    {
+        // Arrange
+        var youtube = new YoutubeClient();
+
+        // Act
+        var channel = await youtube.Channels.GetByHandleAsync(ChannelHandles.Normal);
+
+        // Assert
+        channel.Id.Value.Should().Be("UCm325cMiw9B15xl22_gr6Dw");
+        channel.Url.Should().NotBeNullOrWhiteSpace();
+        channel.Title.Should().Be("Beau Miles");
+        channel.Thumbnails.Should().NotBeEmpty();
+    }
+
+    [Fact]
     public async Task User_can_get_videos_uploaded_by_a_channel()
     {
         // Arrange

--- a/YoutubeExplode.Tests/TestData/ChannelHandles.cs
+++ b/YoutubeExplode.Tests/TestData/ChannelHandles.cs
@@ -1,0 +1,6 @@
+﻿namespace YoutubeExplode.Tests.TestData;
+
+internal static class ChannelHandles
+{
+    public const string Normal = "BeauMiles";
+}

--- a/YoutubeExplode/Channels/ChannelClient.cs
+++ b/YoutubeExplode/Channels/ChannelClient.cs
@@ -82,6 +82,15 @@ public class ChannelClient
         Extract(await _controller.GetChannelPageAsync(channelSlug, cancellationToken));
 
     /// <summary>
+    /// Gets the metadata associated with the channel identified by the specified handle
+    /// or handle URL in the form of https://youtube.com/@handle .
+    /// </summary>
+    public async ValueTask<Channel> GetByHandleAsync(
+        ChannelHandle channelHandle,
+        CancellationToken cancellationToken = default) =>
+        Extract(await _controller.GetChannelPageAsync(channelHandle, cancellationToken));
+
+    /// <summary>
     /// Enumerates videos uploaded by the specified channel.
     /// </summary>
     // TODO: should return <IVideo> sequence instead (breaking change)

--- a/YoutubeExplode/Channels/ChannelController.cs
+++ b/YoutubeExplode/Channels/ChannelController.cs
@@ -48,4 +48,9 @@ internal class ChannelController : YoutubeControllerBase
         ChannelSlug channelSlug,
         CancellationToken cancellationToken = default) =>
         await GetChannelPageAsync("c/" + channelSlug, cancellationToken);
+
+    public async ValueTask<ChannelPageExtractor> GetChannelPageAsync(
+        ChannelHandle channelHandle,
+        CancellationToken cancellationToken = default) =>
+        await GetChannelPageAsync("@" + channelHandle, cancellationToken);
 }

--- a/YoutubeExplode/Channels/ChannelHandle.cs
+++ b/YoutubeExplode/Channels/ChannelHandle.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using YoutubeExplode.Utils.Extensions;
+
+namespace YoutubeExplode.Channels;
+
+/// <summary>
+/// Represents a syntactically valid YouTube channel handle.
+/// </summary>
+public readonly partial struct ChannelHandle
+{
+    /// <summary>
+    /// Raw handle value.
+    /// </summary>
+    public string Value { get; }
+
+    private ChannelHandle(string value) => Value = value;
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}
+
+public readonly partial struct ChannelHandle
+{
+    private static bool IsValid(string channelHandle) =>
+        channelHandle.All(c => char.IsLetterOrDigit(c) || c is '_' or '-' or '.');
+
+    private static string? TryNormalize(string? channelHandleOrUrl)
+    {
+        if (string.IsNullOrWhiteSpace(channelHandleOrUrl))
+            return null;
+
+        // Handle
+        // a-z.0_9
+        if (IsValid(channelHandleOrUrl))
+            return channelHandleOrUrl;
+
+        // URL
+        // https://www.youtube.com/@a-z.0_9
+        var regularMatch = Regex.Match(channelHandleOrUrl, @"youtube\..+?/@(.*?)(?:\?|&|/|$)").Groups[1].Value;
+        if (!string.IsNullOrWhiteSpace(regularMatch) && IsValid(regularMatch))
+            return regularMatch;
+
+        // Invalid input
+        return null;
+    }
+
+    /// <summary>
+    /// Attempts to parse the specified string as a YouTube channel handle
+    /// or handle URL in the form of https://youtube.com/@handle .
+    /// Returns null in case of failure.
+    /// </summary>
+    public static ChannelHandle? TryParse(string? channelHandleOrUrl) =>
+        TryNormalize(channelHandleOrUrl)?.Pipe(handle => new ChannelHandle(handle));
+
+    /// <summary>
+    /// Parses the specified string as a YouTube channel handle
+    /// or handle URL in the form of https://youtube.com/@handle .
+    /// </summary>
+    public static ChannelHandle Parse(string channelHandleOrUrl) =>
+        TryParse(channelHandleOrUrl) ??
+        throw new ArgumentException($"Invalid YouTube channel handle or custom URL '{channelHandleOrUrl}'.");
+
+    /// <summary>
+    /// Converts string to channel handle.
+    /// </summary>
+    public static implicit operator ChannelHandle(string channelHandleOrUrl) => Parse(channelHandleOrUrl);
+
+    /// <summary>
+    /// Converts channel handle to string.
+    /// </summary>
+    public static implicit operator string(ChannelHandle channelHandle) => channelHandle.ToString();
+}


### PR DESCRIPTION
See https://support.google.com/youtube/answer/6180214?hl=en and https://www.youtube.com/handle .

Adds a `public class ChannelHandle` similar to `ChannelSlug` and sensible tests for it.
