### PR TITLE
Handle paid videos in search

### DIFF
--- a/YoutubeExplode.Tests/TestData/VideoIds.cs
+++ b/YoutubeExplode.Tests/TestData/VideoIds.cs
@@ -12,6 +12,7 @@ internal static class VideoIds
     public const string AgeRestrictedSexual = "SkRSXFQerZs";
     public const string AgeRestrictedEmbedRestricted = "hySoCSoH-g8";
     public const string RequiresPurchase = "p3dDcKOFXQg";
+    public const string RequiresPurchaseDistributed = "qs3NZHVM_Ik";
     public const string LiveStream = "jfKfPfyJRdk";
     public const string LiveStreamRecording = "rsAAeyAr-9Y";
     public const string WithBrokenTitle = "4ZJWv6t-PfY";

--- a/YoutubeExplode.Tests/TestData/VideoIds.cs
+++ b/YoutubeExplode.Tests/TestData/VideoIds.cs
@@ -5,7 +5,6 @@ internal static class VideoIds
     public const string Normal = "9bZkp7q19f0";
     public const string Unlisted = "UGh4_HsibAE";
     public const string Private = "pb_hHv3fByo";
-    public const string Paid = "qs3NZHVM_Ik";
     public const string Deleted = "qld9w0b-1ao";
     public const string EmbedRestrictedByYouTube = "_kmeFXjjGfk";
     public const string EmbedRestrictedByAuthor = "MeJVWBSsPAY";

--- a/YoutubeExplode.Tests/TestData/VideoIds.cs
+++ b/YoutubeExplode.Tests/TestData/VideoIds.cs
@@ -5,6 +5,7 @@ internal static class VideoIds
     public const string Normal = "9bZkp7q19f0";
     public const string Unlisted = "UGh4_HsibAE";
     public const string Private = "pb_hHv3fByo";
+    public const string Paid = "qs3NZHVM_Ik";
     public const string Deleted = "qld9w0b-1ao";
     public const string EmbedRestrictedByYouTube = "_kmeFXjjGfk";
     public const string EmbedRestrictedByAuthor = "MeJVWBSsPAY";

--- a/YoutubeExplode.Tests/VideoSpecs.cs
+++ b/YoutubeExplode.Tests/VideoSpecs.cs
@@ -86,7 +86,6 @@ public class VideoSpecs(ITestOutputHelper testOutput)
     [Theory]
     [InlineData(VideoIds.Normal)]
     [InlineData(VideoIds.Unlisted)]
-    [InlineData(VideoIds.Paid)]    
     [InlineData(VideoIds.EmbedRestrictedByYouTube)]
     [InlineData(VideoIds.EmbedRestrictedByAuthor)]
     [InlineData(VideoIds.AgeRestrictedViolent)]

--- a/YoutubeExplode.Tests/VideoSpecs.cs
+++ b/YoutubeExplode.Tests/VideoSpecs.cs
@@ -86,6 +86,7 @@ public class VideoSpecs(ITestOutputHelper testOutput)
     [Theory]
     [InlineData(VideoIds.Normal)]
     [InlineData(VideoIds.Unlisted)]
+    [InlineData(VideoIds.Paid)]    
     [InlineData(VideoIds.EmbedRestrictedByYouTube)]
     [InlineData(VideoIds.EmbedRestrictedByAuthor)]
     [InlineData(VideoIds.AgeRestrictedViolent)]

--- a/YoutubeExplode.Tests/VideoSpecs.cs
+++ b/YoutubeExplode.Tests/VideoSpecs.cs
@@ -86,6 +86,7 @@ public class VideoSpecs(ITestOutputHelper testOutput)
     [Theory]
     [InlineData(VideoIds.Normal)]
     [InlineData(VideoIds.Unlisted)]
+    [InlineData(VideoIds.RequiresPurchaseDistributed)]
     [InlineData(VideoIds.EmbedRestrictedByYouTube)]
     [InlineData(VideoIds.EmbedRestrictedByAuthor)]
     [InlineData(VideoIds.AgeRestrictedViolent)]

--- a/YoutubeExplode/Bridge/SearchResponse.cs
+++ b/YoutubeExplode/Bridge/SearchResponse.cs
@@ -88,6 +88,13 @@ internal partial class SearchResponse
                 ?.GetPropertyOrNull("navigationEndpoint")
                 ?.GetPropertyOrNull("browseEndpoint")
                 ?.GetPropertyOrNull("browseId")
+                ?.GetStringOrNull()
+            ?? content
+                .GetPropertyOrNull("channelThumbnailSupportedRenderers")
+                ?.GetPropertyOrNull("channelThumbnailWithLinkRenderer")
+                ?.GetPropertyOrNull("navigationEndpoint")
+                ?.GetPropertyOrNull("browseEndpoint")
+                ?.GetPropertyOrNull("browseId")
                 ?.GetStringOrNull();
 
         [Lazy]


### PR DESCRIPTION
Added code to ChannelId string to Json parse the Channeld ("browseId") string of a pay-to-watch video such as: https://www.youtube.com/show/SC5q_AUmH7GP_hCdqCc1QQXw
when these type of videos come up in a search query.

<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #774 

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
