### PR TITLE
Fetch video count in playlist metadata

### DIFF
--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -31,6 +31,7 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
         playlist
             .Description.Should()
             .Contain("Digital Analytics Fundamentals course on Analytics Academy");
+        playlist.VideosCount.Should().Be(22);
         playlist.Thumbnails.Should().NotBeEmpty();
     }
 
@@ -82,6 +83,7 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
         playlist.Url.Should().NotBeNullOrWhiteSpace();
         playlist.Title.Should().NotBeNullOrWhiteSpace();
         playlist.Description.Should().NotBeNull();
+        playlist.VideosCount.Should().NotBe(null);
         playlist.Thumbnails.Should().NotBeEmpty();
     }
 

--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -83,7 +83,6 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
         playlist.Url.Should().NotBeNullOrWhiteSpace();
         playlist.Title.Should().NotBeNullOrWhiteSpace();
         playlist.Description.Should().NotBeNull();
-        playlist.VideosCount.Should().NotBe(0);
         playlist.Thumbnails.Should().NotBeEmpty();
     }
 

--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -83,7 +83,7 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
         playlist.Url.Should().NotBeNullOrWhiteSpace();
         playlist.Title.Should().NotBeNullOrWhiteSpace();
         playlist.Description.Should().NotBeNull();
-        playlist.VideosCount.Should().NotBe(null);
+        playlist.VideosCount.Should().NotBe(0);
         playlist.Thumbnails.Should().NotBeEmpty();
     }
 

--- a/YoutubeExplode/Bridge/IPlaylistData.cs
+++ b/YoutubeExplode/Bridge/IPlaylistData.cs
@@ -12,5 +12,7 @@ internal interface IPlaylistData
 
     string? Description { get; }
 
+    int? VideosCount { get; }
+
     IReadOnlyList<ThumbnailData> Thumbnails { get; }
 }

--- a/YoutubeExplode/Bridge/PlaylistBrowseResponse.cs
+++ b/YoutubeExplode/Bridge/PlaylistBrowseResponse.cs
@@ -102,6 +102,27 @@ internal partial class PlaylistBrowseResponse(JsonElement content) : IPlaylistDa
             ?.GetStringOrNull();
 
     [Lazy]
+    public int? VideosCount =>
+        SidebarPrimary
+            ?.GetPropertyOrNull("stats")
+            ?.EnumerateArrayOrNull()
+            ?.FirstOrNull()
+            ?.GetPropertyOrNull("runs")
+            ?.EnumerateArrayOrNull()
+            ?.FirstOrNull()
+            ?.GetPropertyOrNull("text")
+            ?.GetStringOrNull()
+            ?.ParseIntOrNull()
+        ?? SidebarPrimary
+            ?.GetPropertyOrNull("stats")
+            ?.EnumerateArrayOrNull()
+            ?.FirstOrNull()
+            ?.GetPropertyOrNull("simpleText")
+            ?.GetStringOrNull()
+            ?.Split(' ').FirstOrDefault()
+            ?.ParseIntOrNull();
+
+    [Lazy]
     public IReadOnlyList<ThumbnailData> Thumbnails =>
         SidebarPrimary
             ?.GetPropertyOrNull("thumbnailRenderer")

--- a/YoutubeExplode/Bridge/PlaylistBrowseResponse.cs
+++ b/YoutubeExplode/Bridge/PlaylistBrowseResponse.cs
@@ -119,7 +119,8 @@ internal partial class PlaylistBrowseResponse(JsonElement content) : IPlaylistDa
             ?.FirstOrNull()
             ?.GetPropertyOrNull("simpleText")
             ?.GetStringOrNull()
-            ?.Split(' ').FirstOrDefault()
+            ?.Split(' ')
+            ?.FirstOrDefault()
             ?.ParseIntOrNull();
 
     [Lazy]

--- a/YoutubeExplode/Bridge/PlaylistNextResponse.cs
+++ b/YoutubeExplode/Bridge/PlaylistNextResponse.cs
@@ -35,27 +35,23 @@ internal partial class PlaylistNextResponse(JsonElement content) : IPlaylistData
     public string? Description => null;
 
     [Lazy]
-    public bool? IsInfinite => ContentRoot?.GetPropertyOrNull("isInfinite")?.GetBoolean();
-
     public int? VideosCount =>
-        IsInfinite == true
-            ? int.MaxValue
-            : ContentRoot
-                ?.GetPropertyOrNull("totalVideosText")
-                ?.GetPropertyOrNull("runs")
-                ?.EnumerateArrayOrNull()
-                ?.FirstOrNull()
-                ?.GetPropertyOrNull("text")
-                ?.GetStringOrNull()
-                ?.ParseIntOrNull()
-                ?? ContentRoot
-                    ?.GetPropertyOrNull("videoCountText")
-                    ?.GetPropertyOrNull("runs")
-                    ?.EnumerateArrayOrNull()
-                    ?.ElementAtOrNull(2)
-                    ?.GetPropertyOrNull("text")
-                    ?.GetStringOrNull()
-                    ?.ParseIntOrNull();
+        ContentRoot
+            ?.GetPropertyOrNull("totalVideosText")
+            ?.GetPropertyOrNull("runs")
+            ?.EnumerateArrayOrNull()
+            ?.FirstOrNull()
+            ?.GetPropertyOrNull("text")
+            ?.GetStringOrNull()
+            ?.ParseIntOrNull()
+        ?? ContentRoot
+            ?.GetPropertyOrNull("videoCountText")
+            ?.GetPropertyOrNull("runs")
+            ?.EnumerateArrayOrNull()
+            ?.ElementAtOrNull(2)
+            ?.GetPropertyOrNull("text")
+            ?.GetStringOrNull()
+            ?.ParseIntOrNull();
 
     [Lazy]
     public IReadOnlyList<ThumbnailData> Thumbnails => Videos.FirstOrDefault()?.Thumbnails ?? [];

--- a/YoutubeExplode/Bridge/PlaylistNextResponse.cs
+++ b/YoutubeExplode/Bridge/PlaylistNextResponse.cs
@@ -34,6 +34,8 @@ internal partial class PlaylistNextResponse(JsonElement content) : IPlaylistData
 
     public string? Description => null;
 
+    public int? VideosCount => null;
+
     [Lazy]
     public IReadOnlyList<ThumbnailData> Thumbnails => Videos.FirstOrDefault()?.Thumbnails ?? [];
 

--- a/YoutubeExplode/Bridge/PlaylistNextResponse.cs
+++ b/YoutubeExplode/Bridge/PlaylistNextResponse.cs
@@ -34,7 +34,28 @@ internal partial class PlaylistNextResponse(JsonElement content) : IPlaylistData
 
     public string? Description => null;
 
-    public int? VideosCount => null;
+    [Lazy]
+    public bool? IsInfinite => ContentRoot?.GetPropertyOrNull("isInfinite")?.GetBoolean();
+
+    public int? VideosCount =>
+        IsInfinite == true
+            ? int.MaxValue
+            : ContentRoot
+                ?.GetPropertyOrNull("totalVideosText")
+                ?.GetPropertyOrNull("runs")
+                ?.EnumerateArrayOrNull()
+                ?.FirstOrNull()
+                ?.GetPropertyOrNull("text")
+                ?.GetStringOrNull()
+                ?.ParseIntOrNull()
+                ?? ContentRoot
+                    ?.GetPropertyOrNull("videoCountText")
+                    ?.GetPropertyOrNull("runs")
+                    ?.EnumerateArrayOrNull()
+                    ?.ElementAtOrNull(2)
+                    ?.GetPropertyOrNull("text")
+                    ?.GetStringOrNull()
+                    ?.ParseIntOrNull();
 
     [Lazy]
     public IReadOnlyList<ThumbnailData> Thumbnails => Videos.FirstOrDefault()?.Thumbnails ?? [];

--- a/YoutubeExplode/Playlists/Playlist.cs
+++ b/YoutubeExplode/Playlists/Playlist.cs
@@ -12,7 +12,7 @@ public class Playlist(
     string title,
     Author? author,
     string description,
-    int videosCount,
+    int? videosCount,
     IReadOnlyList<Thumbnail> thumbnails
 ) : IPlaylist
 {
@@ -36,7 +36,10 @@ public class Playlist(
     /// <summary>
     /// Count of total videos.
     /// </summary>
-    public int VideosCount { get; } = videosCount;
+    /// <remarks>
+    /// May be null in case of playlists with infinite videos (e.g. mixes).
+    /// </remarks>
+    public int? VideosCount { get; } = videosCount;
 
     /// <inheritdoc />
     public IReadOnlyList<Thumbnail> Thumbnails { get; } = thumbnails;

--- a/YoutubeExplode/Playlists/Playlist.cs
+++ b/YoutubeExplode/Playlists/Playlist.cs
@@ -12,6 +12,7 @@ public class Playlist(
     string title,
     Author? author,
     string description,
+    int videosCount,
     IReadOnlyList<Thumbnail> thumbnails
 ) : IPlaylist
 {
@@ -31,6 +32,11 @@ public class Playlist(
     /// Playlist description.
     /// </summary>
     public string Description { get; } = description;
+
+    /// <summary>
+    /// Count of total videos.
+    /// </summary>
+    public int VideosCount { get; } = videosCount;
 
     /// <inheritdoc />
     public IReadOnlyList<Thumbnail> Thumbnails { get; } = thumbnails;

--- a/YoutubeExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeExplode/Playlists/PlaylistClient.cs
@@ -42,6 +42,8 @@ public class PlaylistClient(HttpClient http)
         // System playlists have no description
         var description = response.Description ?? "";
 
+        var videosCount = response.VideosCount ?? 0;
+
         var thumbnails = response
             .Thumbnails.Select(t =>
             {
@@ -63,7 +65,7 @@ public class PlaylistClient(HttpClient http)
             })
             .ToArray();
 
-        return new Playlist(playlistId, title, author, description, thumbnails);
+        return new Playlist(playlistId, title, author, description, videosCount, thumbnails);
     }
 
     /// <summary>

--- a/YoutubeExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeExplode/Playlists/PlaylistClient.cs
@@ -42,7 +42,7 @@ public class PlaylistClient(HttpClient http)
         // System playlists have no description
         var description = response.Description ?? "";
 
-        var videosCount = response.VideosCount ?? 0;
+        var videosCount = response.VideosCount;
 
         var thumbnails = response
             .Thumbnails.Select(t =>


### PR DESCRIPTION
Closes #356
// Provided solution wasn't actually a solution. Just a workaround.

---

#### Added support for "vidoes count" property for playlist fetching:
Knowing the estimate videos count provided by the offical YouTube API without having to reiterate over the entire video collection is needed (especially when there are hundreds of videos in the playlist)
- Added `int VideosCount` to `Playlist`
- Added `int? VideosCount` to `IPlaylistData`, `PlaylistBrowseResponse`, `PlaylistNextResponse`
- Updated `PlaylistSpecs`-Tests