### PR TITLE
GetVideosAsync fix

### DIFF
--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -189,4 +189,16 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
         // Assert
         videos.Should().HaveCount(10);
     }
+
+    [Fact]
+    public async Task I_can_get_videos_included_in_a_buggy_playlist()
+    {
+        var youtube = new YoutubeClient();
+
+        // Act
+        var videos = await youtube.Playlists.GetVideosAsync(PlaylistIds.EnormousDuplicates);
+
+        // Assert
+        videos.Should().HaveCountGreaterOrEqualTo(3_900);
+    }
 }

--- a/YoutubeExplode.Tests/PlaylistSpecs.cs
+++ b/YoutubeExplode.Tests/PlaylistSpecs.cs
@@ -191,8 +191,9 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
     }
 
     [Fact]
-    public async Task I_can_get_videos_included_in_a_buggy_playlist()
+    public async Task I_can_get_videos_included_in_a_playlist_with_a_lot_of_duplicate()
     {
+        // Arrange
         var youtube = new YoutubeClient();
 
         // Act
@@ -200,5 +201,6 @@ public class PlaylistSpecs(ITestOutputHelper testOutput)
 
         // Assert
         videos.Should().HaveCountGreaterOrEqualTo(3_900);
+        videos.Should().OnlyHaveUniqueItems();
     }
 }

--- a/YoutubeExplode.Tests/TestData/PlaylistIds.cs
+++ b/YoutubeExplode.Tests/TestData/PlaylistIds.cs
@@ -12,4 +12,5 @@ internal static class PlaylistIds
     public const string UserUploads = "UUTMt7iMWa7jy0fNXIktwyLA";
     public const string Weird = "PL601B2E69B03FAB9D";
     public const string ContainsLongVideos = "PLkk2FsMngwGi9FNkWIoNZlfqglcldj_Zs";
+    public const string EnormousDuplicates = "PLI_eFW8NAFzYAXZ5DrU6E6mQ_XfhaLBUX";
 }

--- a/YoutubeExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeExplode/Playlists/PlaylistClient.cs
@@ -4,10 +4,8 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using YoutubeExplode.Bridge;
 using YoutubeExplode.Common;
 using YoutubeExplode.Exceptions;
-using YoutubeExplode.Utils.Extensions;
 using YoutubeExplode.Videos;
 
 namespace YoutubeExplode.Playlists;
@@ -101,8 +99,6 @@ public class PlaylistClient(HttpClient http)
 
             foreach (var videoData in originalVideos)
             {
-                PlaylistVideoData? lastVideoData = null ?? response.Videos.Last();
-
                 var videoId =
                     videoData.Id
                     ?? throw new YoutubeExplodeException("Failed to extract the video ID.");
@@ -114,13 +110,7 @@ public class PlaylistClient(HttpClient http)
                     ?? throw new YoutubeExplodeException("Failed to extract the video index.");
 
                 if (!encounteredIds.Add(videoId))
-                {
-                    /*if (videoData.Id != lastVideoData.Id)
-                    {
-                        continue;
-                    }*/
                     continue;
-                }
 
                 var videoTitle =
                     videoData.Title


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #749 

For some reasons, YouTube provided videos, which were already added and this caused to stop function to continue fetch next videos.
Added a separate list, which filter `response.Videos` by searching added video ID in `encounteredIds`. 

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
