### PR TITLE
Add `ViewCount` to `VideoSearchResult`

### DIFF
--- a/YoutubeExplode/Bridge/SearchResponse.cs
+++ b/YoutubeExplode/Bridge/SearchResponse.cs
@@ -123,13 +123,6 @@ internal partial class SearchResponse
                 ?.ParseLongOrNull();
 
         [Lazy]
-        public string? SimpleUploadDate =>
-            content
-                .GetPropertyOrNull("publishedTimeText")
-                ?.GetPropertyOrNull("simpleText")
-                ?.GetStringOrNull();
-
-        [Lazy]
         public IReadOnlyList<ThumbnailData> Thumbnails =>
             content
                 .GetPropertyOrNull("thumbnail")

--- a/YoutubeExplode/Bridge/SearchResponse.cs
+++ b/YoutubeExplode/Bridge/SearchResponse.cs
@@ -114,6 +114,22 @@ internal partial class SearchResponse
                 .ParseTimeSpanOrNull([@"m\:ss", @"mm\:ss", @"h\:mm\:ss", @"hh\:mm\:ss"]);
 
         [Lazy]
+        public long? ViewCount =>
+            content
+                .GetPropertyOrNull("viewCountText")
+                ?.GetPropertyOrNull("simpleText")
+                ?.GetStringOrNull()
+                ?.StripNonDigit()
+                ?.ParseLongOrNull();
+
+        [Lazy]
+        public string? SimpleUploadDate =>
+            content
+                .GetPropertyOrNull("publishedTimeText")
+                ?.GetPropertyOrNull("simpleText")
+                ?.GetStringOrNull();
+
+        [Lazy]
         public IReadOnlyList<ThumbnailData> Thumbnails =>
             content
                 .GetPropertyOrNull("thumbnail")

--- a/YoutubeExplode/Bridge/SearchResponse.cs
+++ b/YoutubeExplode/Bridge/SearchResponse.cs
@@ -178,6 +178,22 @@ internal partial class SearchResponse
                 ?.GetStringOrNull();
 
         [Lazy]
+        public long? ViewCount =>
+            content
+                .GetPropertyOrNull("viewCountText")
+                ?.GetPropertyOrNull("simpleText")
+                ?.GetStringOrNull()
+                ?.StripNonDigit()
+                ?.ParseLongOrNull();
+
+        [Lazy]
+        public string? SimpleUploadDate =>
+            content
+                .GetPropertyOrNull("publishedTimeText")
+                ?.GetPropertyOrNull("simpleText")
+                ?.GetStringOrNull();
+
+        [Lazy]
         public IReadOnlyList<ThumbnailData> Thumbnails =>
             content
                 .GetPropertyOrNull("thumbnails")

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -72,8 +72,6 @@ public class SearchClient(HttpClient http)
 
                 var viewCount = videoData.ViewCount ?? 0;
 
-                var simpleUploadDate = videoData.SimpleUploadDate;
-
                 var videoThumbnails = videoData
                     .Thumbnails.Select(t =>
                     {
@@ -108,7 +106,6 @@ public class SearchClient(HttpClient http)
                     new Author(videoChannelId, videoChannelTitle),
                     videoData.Duration,
                     viewCount,
-                    simpleUploadDate,
                     videoThumbnails
                 );
 

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -70,15 +70,9 @@ public class SearchClient(HttpClient http)
                     videoData.ChannelId
                     ?? throw new YoutubeExplodeException("Failed to extract the video channel ID.");
 
-                var viewCount =
-                    videoData.ViewCount
-                    ?? throw new YoutubeExplodeException("Failed to extract the video view count.");
+                var viewCount = videoData.ViewCount ?? 0;
 
-                var simpleUploadDate =
-                    videoData.SimpleUploadDate
-                    ?? throw new YoutubeExplodeException(
-                        "Failed to extract the video simple upload date."
-                    );
+                var simpleUploadDate = videoData.SimpleUploadDate;
 
                 var videoThumbnails = videoData
                     .Thumbnails.Select(t =>

--- a/YoutubeExplode/Search/SearchClient.cs
+++ b/YoutubeExplode/Search/SearchClient.cs
@@ -70,6 +70,16 @@ public class SearchClient(HttpClient http)
                     videoData.ChannelId
                     ?? throw new YoutubeExplodeException("Failed to extract the video channel ID.");
 
+                var viewCount =
+                    videoData.ViewCount
+                    ?? throw new YoutubeExplodeException("Failed to extract the video view count.");
+
+                var simpleUploadDate =
+                    videoData.SimpleUploadDate
+                    ?? throw new YoutubeExplodeException(
+                        "Failed to extract the video simple upload date."
+                    );
+
                 var videoThumbnails = videoData
                     .Thumbnails.Select(t =>
                     {
@@ -103,6 +113,8 @@ public class SearchClient(HttpClient http)
                     videoTitle,
                     new Author(videoChannelId, videoChannelTitle),
                     videoData.Duration,
+                    viewCount,
+                    simpleUploadDate,
                     videoThumbnails
                 );
 

--- a/YoutubeExplode/Search/VideoSearchResult.cs
+++ b/YoutubeExplode/Search/VideoSearchResult.cs
@@ -34,10 +34,20 @@ public class VideoSearchResult(
     /// <inheritdoc />
     public TimeSpan? Duration { get; } = duration;
 
-    /// <inheritdoc />
-    public long? ViewCount { get; } = viewCount;
+    /// <summary>
+    /// Video view count.
+    /// </summary>
+    /// <remarks>
+    /// May be little bit inaccurate due to YouTube's view count caching.
+    /// </remarks>
+    public long ViewCount { get; } = viewCount;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Video simplyfied upload date.
+    /// </summary>
+    /// <remarks>
+    /// May be null if the video is planned premiere or live stream.
+    /// </remarks>
     public string? SimpleUploadDate { get; } = simpleUploadDate;
 
     /// <inheritdoc />

--- a/YoutubeExplode/Search/VideoSearchResult.cs
+++ b/YoutubeExplode/Search/VideoSearchResult.cs
@@ -15,7 +15,6 @@ public class VideoSearchResult(
     Author author,
     TimeSpan? duration,
     long viewCount,
-    string? simpleUploadDate,
     IReadOnlyList<Thumbnail> thumbnails
 ) : ISearchResult, IVideo
 {
@@ -41,14 +40,6 @@ public class VideoSearchResult(
     /// May be little bit inaccurate due to YouTube's view count caching.
     /// </remarks>
     public long ViewCount { get; } = viewCount;
-
-    /// <summary>
-    /// Video simplyfied upload date.
-    /// </summary>
-    /// <remarks>
-    /// May be null if the video is planned premiere or live stream.
-    /// </remarks>
-    public string? SimpleUploadDate { get; } = simpleUploadDate;
 
     /// <inheritdoc />
     public IReadOnlyList<Thumbnail> Thumbnails { get; } = thumbnails;

--- a/YoutubeExplode/Search/VideoSearchResult.cs
+++ b/YoutubeExplode/Search/VideoSearchResult.cs
@@ -14,7 +14,7 @@ public class VideoSearchResult(
     string title,
     Author author,
     TimeSpan? duration,
-    long? viewCount,
+    long viewCount,
     string? simpleUploadDate,
     IReadOnlyList<Thumbnail> thumbnails
 ) : ISearchResult, IVideo

--- a/YoutubeExplode/Search/VideoSearchResult.cs
+++ b/YoutubeExplode/Search/VideoSearchResult.cs
@@ -14,6 +14,8 @@ public class VideoSearchResult(
     string title,
     Author author,
     TimeSpan? duration,
+    long? viewCount,
+    string? simpleUploadDate,
     IReadOnlyList<Thumbnail> thumbnails
 ) : ISearchResult, IVideo
 {
@@ -31,6 +33,12 @@ public class VideoSearchResult(
 
     /// <inheritdoc />
     public TimeSpan? Duration { get; } = duration;
+
+    /// <inheritdoc />
+    public long? ViewCount { get; } = viewCount;
+
+    /// <inheritdoc />
+    public string? SimpleUploadDate { get; } = simpleUploadDate;
 
     /// <inheritdoc />
     public IReadOnlyList<Thumbnail> Thumbnails { get; } = thumbnails;


### PR DESCRIPTION
Hey there!

I know that in issue #515 you mentioned not wanting non-deterministic properties in the library, but I thought maybe today you'd be in a better mood and might press that merge button! If still no, feel free to close this.

Also, just to mention, the ViewCount property isn't non-deterministic - we can extract the exact number of views, well kind of exact, propably due to how youtube cache it. See image below.

<img width="1103" alt="Screenshot 2024-10-20 052510" src="https://github.com/user-attachments/assets/4216a5c6-ad03-4649-b950-0322662eee51">

I couldn't sleep if I didn't at least try because these properties would be really useful to me. 👉🏻👈🏻

Hope you'll consider it!

Fuck russia.