### PR TITLE
Add missing case when trying to parse video ID

### DIFF
--- a/YoutubeExplode.Tests/VideoIdSpecs.cs
+++ b/YoutubeExplode.Tests/VideoIdSpecs.cs
@@ -22,6 +22,7 @@ public class VideoIdSpecs
 
     [Theory]
     [InlineData("youtube.com/watch?v=yIVRs6YSbOM", "yIVRs6YSbOM")]
+    [InlineData("youtu.be/watch?v=Fcds0_MrgNU", "Fcds0_MrgNU")]
     [InlineData("youtu.be/yIVRs6YSbOM", "yIVRs6YSbOM")]
     [InlineData("youtube.com/embed/yIVRs6YSbOM", "yIVRs6YSbOM")]
     [InlineData("youtube.com/shorts/sKL1vjP0tIo", "sKL1vjP0tIo")]

--- a/YoutubeExplode/Videos/VideoId.cs
+++ b/YoutubeExplode/Videos/VideoId.cs
@@ -59,6 +59,18 @@ public partial struct VideoId
                 return id;
         }
 
+        // Try to extract the ID from the URL (shortened)
+        // https://youtu.be/watch?v=Fcds0_MrgNU
+        {
+            var id = Regex
+                .Match(videoIdOrUrl, @"youtu\.be/watch.*?v=(.*?)(?:\?|&|/|$)")
+                .Groups[1]
+                .Value.Pipe(WebUtility.UrlDecode);
+
+            if (!string.IsNullOrWhiteSpace(id) && IsValid(id))
+                return id;
+        }
+
         // Try to extract the ID from the URL (embedded)
         // https://www.youtube.com/embed/yIVRs6YSbOM
         {

--- a/YoutubeExplode/Videos/VideoId.cs
+++ b/YoutubeExplode/Videos/VideoId.cs
@@ -59,7 +59,7 @@ public partial struct VideoId
                 return id;
         }
 
-        // Try to extract the ID from the URL (shortened)
+        // Try to extract the ID from the URL (partially shortened)
         // https://youtu.be/watch?v=Fcds0_MrgNU
         {
             var id = Regex

--- a/YoutubeExplode/Videos/VideoId.cs
+++ b/YoutubeExplode/Videos/VideoId.cs
@@ -47,11 +47,11 @@ public partial struct VideoId
                 return id;
         }
 
-        // Try to extract the ID from the URL (shortened)
-        // https://youtu.be/yIVRs6YSbOM
+        // Try to extract the ID from the URL (partially shortened)
+        // https://youtu.be/watch?v=Fcds0_MrgNU
         {
             var id = Regex
-                .Match(videoIdOrUrl, @"youtu\.be/(.*?)(?:\?|&|/|$)")
+                .Match(videoIdOrUrl, @"youtu\.be/watch.*?v=(.*?)(?:\?|&|/|$)")
                 .Groups[1]
                 .Value.Pipe(WebUtility.UrlDecode);
 
@@ -59,11 +59,11 @@ public partial struct VideoId
                 return id;
         }
 
-        // Try to extract the ID from the URL (partially shortened)
-        // https://youtu.be/watch?v=Fcds0_MrgNU
+        // Try to extract the ID from the URL (shortened)
+        // https://youtu.be/yIVRs6YSbOM
         {
             var id = Regex
-                .Match(videoIdOrUrl, @"youtu\.be/watch.*?v=(.*?)(?:\?|&|/|$)")
+                .Match(videoIdOrUrl, @"youtu\.be/(.*?)(?:\?|&|/|$)")
                 .Groups[1]
                 .Value.Pipe(WebUtility.UrlDecode);
 


### PR DESCRIPTION
This PR only adds a missing case when trying to parse the video ID. I ran into it when using this video link:
https://youtu.be/watch?v=Fcds0_MrgNU