### PR TITLE
Fix custom cookies getting overwritten

### DIFF
--- a/YoutubeExplode/YoutubeHttpHandler.cs
+++ b/YoutubeExplode/YoutubeHttpHandler.cs
@@ -28,6 +28,7 @@ internal class YoutubeHttpHandler : ClientDelegatingHandler
         foreach (var cookie in initialCookies)
             _cookieContainer.Add(cookie);
 
+        // Don't overwrite custom cookie
         // Consent to the use of cookies on YouTube.
         // This is required to access some personalized content, such as mix playlists.
         // https://github.com/Tyrrrz/YoutubeExplode/issues/730

--- a/YoutubeExplode/YoutubeHttpHandler.cs
+++ b/YoutubeExplode/YoutubeHttpHandler.cs
@@ -35,7 +35,7 @@ internal class YoutubeHttpHandler : ClientDelegatingHandler
             }
         );
 
-        // Pre-fill cookies
+        // Add user-supplied cookies
         foreach (var cookie in initialCookies)
             _cookieContainer.Add(cookie);
     }

--- a/YoutubeExplode/YoutubeHttpHandler.cs
+++ b/YoutubeExplode/YoutubeHttpHandler.cs
@@ -24,11 +24,6 @@ internal class YoutubeHttpHandler : ClientDelegatingHandler
     )
         : base(http, disposeClient)
     {
-        // Pre-fill cookies
-        foreach (var cookie in initialCookies)
-            _cookieContainer.Add(cookie);
-
-        // Don't overwrite custom cookie
         // Consent to the use of cookies on YouTube.
         // This is required to access some personalized content, such as mix playlists.
         // https://github.com/Tyrrrz/YoutubeExplode/issues/730
@@ -39,6 +34,10 @@ internal class YoutubeHttpHandler : ClientDelegatingHandler
                 Domain = "youtube.com",
             }
         );
+
+        // Pre-fill cookies
+        foreach (var cookie in initialCookies)
+            _cookieContainer.Add(cookie);
     }
 
     private string? TryGenerateAuthHeaderValue(Uri uri)


### PR DESCRIPTION
To allow providing a custom Cookie like mentioned in the Authentication-part of the Readme:
```
using YoutubeExplode;

// Perform authentication and extract cookies
var cookies = ...;

// Cookie collection must be of type IReadOnlyList<System.Net.Cookie>
var youtube = new YoutubeClient(cookies);
``` 
That custom cookie must always have priority over the default/fallback cookie for this to work. I changed the order so to meet this requirement

Closes #909


