### PR TITLE
Change the client to avoid the 403 error

### DIFF
--- a/YoutubeExplode/Videos/VideoController.cs
+++ b/YoutubeExplode/Videos/VideoController.cs
@@ -172,10 +172,8 @@ internal class VideoController(HttpClient http)
               "videoId": {{Json.Serialize(videoId)}},
               "context": {
                 "client": {
-                  "clientName": "ANDROID",
-                  "clientVersion": "20.10.38",
-                  "osName": "Android",
-                  "osVersion": "11",
+                  "clientName": "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+                  "clientVersion": "2.0",
                   "visitorData": {{Json.Serialize(visitorData)}},
                   "hl": "en",
                   "gl": "US",


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

While look into www I found that issue is related to google now require a POToken, or something like that, and while I didn't find a way to generate/grab/use this token I found a PR that provides a workaround for that issue. Looks like there's one client that doesn't need that token (yet).

- https://github.com/yt-dlp/yt-dlp/pull/14693/files#diff-443dcfbd960da6a3264f7d52869636689f41f36daa876ade16a050c86c542ccdR223

The downside, that I found in my tests, is that the number of results for Muxed (video + audio) are reduced, but you know is better than nothing.

<!-- Please specify the issue(s) addressed by this pull request: -->

Related to #853 