### PR TITLE
Get the batch of working playlist videos and stop on the unavailable batch

### DIFF
--- a/YoutubeExplode/Playlists/PlaylistClient.cs
+++ b/YoutubeExplode/Playlists/PlaylistClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using YoutubeExplode.Bridge;
 using YoutubeExplode.Common;
 using YoutubeExplode.Exceptions;
 using YoutubeExplode.Videos;
@@ -83,13 +84,22 @@ public class PlaylistClient(HttpClient http)
 
         do
         {
-            var response = await _controller.GetPlaylistNextResponseAsync(
-                playlistId,
-                lastVideoId,
-                lastVideoIndex,
-                visitorData,
-                cancellationToken
-            );
+            PlaylistNextResponse response;
+            try
+            {
+                response = await _controller.GetPlaylistNextResponseAsync(
+                    playlistId,
+                    lastVideoId,
+                    lastVideoIndex,
+                    visitorData,
+                    cancellationToken
+                );
+            }
+            catch (PlaylistUnavailableException)
+            {
+                // Stop enumeration if the playlist becomes unavailable
+                yield break;
+            }
 
             var videos = new List<PlaylistVideo>();
 

--- a/YoutubeExplode/Playlists/PlaylistController.cs
+++ b/YoutubeExplode/Playlists/PlaylistController.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using YoutubeExplode.Bridge;
@@ -125,6 +126,10 @@ internal class PlaylistController(HttpClient http)
 
                     continue;
                 }
+
+                // If the response contains videos, proceed with them even if the playlist is marked unavailable
+                if (playlistResponse.Videos.Any())
+                    return playlistResponse;
 
                 throw new PlaylistUnavailableException(
                     $"Playlist '{playlistId}' is not available."

--- a/YoutubeExplode/Playlists/PlaylistController.cs
+++ b/YoutubeExplode/Playlists/PlaylistController.cs
@@ -127,8 +127,9 @@ internal class PlaylistController(HttpClient http)
                     continue;
                 }
 
-                // If the response contains videos, proceed with them even if the playlist is marked unavailable
-                if (playlistResponse.Videos.Any())
+                // If the response contains videos, proceed with them even if the playlist is marked unavailable,
+                // but only on the final retry attempt.
+                if (retriesRemaining == 0 && playlistResponse.Videos.Any())
                     return playlistResponse;
 
                 throw new PlaylistUnavailableException(


### PR DESCRIPTION
Partially fixes #921 by handling unavailable playlist batches gracefully.

**Before:** Fetching crashed with `PlaylistUnavailableException` on any unavailable batch.

**After:** Catches the exception to stop enumeration without crashing. 

Note: In practice, unavailable batches omit all videos, so this prevents crashes but may still stop early.
We may think of further improvements (like jumping over batches) can extend coverage but also may miss smth before if the jumping to indices is too large.