### PR TITLE
Improve MP3 conversion quality

### DIFF
--- a/YoutubeExplode.Converter/Converter.cs
+++ b/YoutubeExplode.Converter/Converter.cs
@@ -91,7 +91,9 @@ internal partial class Converter(VideoClient videoClient, FFmpeg ffmpeg, Convers
 
         // MP3: explicitly specify the bitrate for audio streams, otherwise their metadata
         // might contain invalid total duration.
-        // https://superuser.com/a/893044
+// MP3: explicitly specify the quality for audio streams, otherwise their metadata
+// might contain invalid total duration.
+// https://superuser.com/a/893044
         if (container == Container.Mp3)
         {
             var lastAudioStreamIndex = 0;


### PR DESCRIPTION
This closes #926 by using `-q:a:<stream> 0` instead of `-b:a:<stream> <input_stream_bitrate>`

Notice a "drawback" of this approach is, output mp3 files will have considerably higher size. For the "not-audiophile" people and large libraries, this might mean a considerable impact.

The expected average increase is of 2/3rs (66%), but it depends both on the input quality and input codec. Opus in particular should always mean bigger files as it usually packs better quality in smaller bitrates in comparison to lame/mp3.

Ideally YoutubeExplode should accept quality control on the MP3 output, but that's really falling into a "new feature" category and is probably not the focus anymore. Having the best quality possible leaves room for manually reducing the quality after the download if size matters over quality.

p.s.: it was not my decision to join the lines, Visual Studio done it on its own will. Shall we bend to IA's will this time? :)