### PR TITLE
Handle content length being null in StreamClient

### DIFF
--- a/YoutubeExplode/Videos/Streams/StreamClient.cs
+++ b/YoutubeExplode/Videos/Streams/StreamClient.cs
@@ -113,8 +113,7 @@ public class StreamClient(HttpClient http)
             }
 
             var contentLength = await TryGetContentLengthAsync(streamData, url, cancellationToken);
-            if (contentLength is null)
-                continue;
+            var fileSize = contentLength is null ? new FileSize() : new FileSize(contentLength.Value);
 
             var container =
                 streamData.Container?.Pipe(s => new Container(s))
@@ -151,7 +150,7 @@ public class StreamClient(HttpClient http)
                     var streamInfo = new MuxedStreamInfo(
                         url,
                         container,
-                        new FileSize(contentLength.Value),
+                        fileSize,
                         bitrate,
                         streamData.AudioCodec,
                         audioLanguage,
@@ -169,7 +168,7 @@ public class StreamClient(HttpClient http)
                     var streamInfo = new VideoOnlyStreamInfo(
                         url,
                         container,
-                        new FileSize(contentLength.Value),
+                        fileSize,
                         bitrate,
                         streamData.VideoCodec,
                         videoQuality,
@@ -185,7 +184,7 @@ public class StreamClient(HttpClient http)
                 var streamInfo = new AudioOnlyStreamInfo(
                     url,
                     container,
-                    new FileSize(contentLength.Value),
+                    fileSize,
                     bitrate,
                     streamData.AudioCodec,
                     audioLanguage,


### PR DESCRIPTION
Allow downloading videos of unknown content length. That is necessary in scenarios when we the videos are being streamed.

<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #ISSUE_NUMBER

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
